### PR TITLE
[releng] Rename nigtly to simply builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Github Releases](https://img.shields.io/github/downloads/eclipse-embed-cdt/eclipse-plugins/latest/total.svg)](https://github.com/eclipse-embed-cdt/eclipse-plugins/releases/latest) 
 [![Github Releases](https://img.shields.io/github/downloads/eclipse-embed-cdt/eclipse-plugins/total.svg)](https://github.com/eclipse-embed-cdt/eclipse-plugins/releases/latest) 
 [![SourceForge](https://img.shields.io/sourceforge/dt/gnuarmeclipse.svg?label=SF%20downloads)](https://sourceforge.net/projects/gnuarmeclipse/files/) 
-[![Build Status](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fembed-cdt%2Fjob%2Fnightly%2Fjob%2Fdevelop%2F)](https://ci.eclipse.org/embed-cdt/job/nightly/job/develop/) 
+[![Build Status](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.eclipse.org%2Fembed-cdt%2Fjob%2Fbuilds%2Fjob%2Fdevelop%2F)](https://ci.eclipse.org/embed-cdt/job/builds/job/develop/) 
 
 # The Eclipse Embedded CDT plug-ins
 
@@ -26,7 +26,7 @@ Eclipse Marketplace; search for **GNU MCU Eclipse**.
  * Stable: http://gnu-mcu-eclipse.netlify.com/v4-neon-updates  
     This is the official release; it is also referred by the Eclipse 
     Marketplace and the same content is packed as **Eclipse IDE for C/C++ Developers**.
- * Pre-release versions: https://download.eclipse.org/embed-cdt/nightly/develop/
+ * Pre-release versions: https://download.eclipse.org/embed-cdt/builds/develop/
     Usually this site should be safe to use, but use it with caution.
  * Experimental versions: http://gnu-mcu-eclipse.netlify.com/v4-neon-updates-experimental  
     Sometimes you can use this site to test some features that are not 

--- a/builds.Jenkinsfile
+++ b/builds.Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
         stage('Upload') {
             steps {
                 sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
-                   sh './scripts/nightly-upload.sh'
+                   sh './scripts/builds-upload.sh'
                 }
             }
         }

--- a/scripts/builds-upload.sh
+++ b/scripts/builds-upload.sh
@@ -11,7 +11,7 @@ SCP="scp"
 P2ZIP=repositories/ilg.gnumcueclipse.repository/target/ilg.gnumcueclipse.repository-*.zip
 # The download location is chosen to be a non-mirrored URL according to
 #  https://wiki.eclipse.org/IT_Infrastructure_Doc#Use_mirror_sites.2Fsee_which_mirrors_are_mirroring_my_files.3F
-DOWNLOAD=/home/data/httpd/download.eclipse.org/embed-cdt/nightly/${BRANCH_NAME}
+DOWNLOAD=/home/data/httpd/download.eclipse.org/embed-cdt/builds/${BRANCH_NAME}
 
 ${SSH} rm -rf ${DOWNLOAD}-temp
 ${SSH} rm -rf ${DOWNLOAD}-last


### PR DESCRIPTION
This is to better reflect that the builds are CI builds not strictly
nightly.

In addition to accepting this PR the changes to make are:

- [ ] [Configure](https://ci.eclipse.org/embed-cdt/job/nightly/configure) the Jenkins job to change the `Build Configuration -> Script path` to be `build.Jenkinsfile`
- [ ] [Rename](https://ci.eclipse.org/embed-cdt/job/nightly/confirm-rename) the Jenkins job
- [ ] Delete the "nightly" directory on download.eclipse.org by editing* [simple-script-job](https://ci.eclipse.org/embed-cdt/job/simple-script-job/configure) to do 
`${SSH} rm -rf ${DOWNLOAD_ROOT}/nightly`


\* If you want to create a new simple job to run a script, the steps are as follows. Note that soon, for simple download.eclipse.org operations there is the promise of a new web interface for managing artifacts there.

1. Navigate to CI [home page](https://ci.eclipse.org/embed-cdt/)
2. Click [New Item](https://ci.eclipse.org/embed-cdt/view/all/newJob) in the top left
3. Name the item
4. Choose `Freestyle Project`
5. Press `OK`
6. Enable `Build Environment -> SSH Agent` (see Eclipse specific [help](https://wiki.eclipse.org/Jenkins#How_do_I_deploy_artifacts_to_download.eclipse.org.3F))
7. Under `Build` choose `Add build step` and choose `Execute shell`
8. Type your script**
9. Save and run the build

** The Eclipse [help](https://wiki.eclipse.org/Jenkins#How_do_I_deploy_artifacts_to_download.eclipse.org.3F) has some info about how to ssh and scp. This is what I do:

Set environment variables as follows:
```
SSHUSER="genie.embed-cdt@projects-storage.eclipse.org"
SSH="ssh ${SSHUSER}"
SCP="scp"

DOWNLOAD_ROOT=/home/data/httpd/download.eclipse.org/embed-cdt
```
and then I can SSH or SCP like this:
```
${SSH} mkdir -p ${DOWNLOAD_ROOT}/temp
${SCP} file-to-upload ${SSHUSER}:${DOWNLOAD_ROOT}/temp/filename
```

