### PR TITLE
Bug #450: Add Eclipse-SourceReferences header to MANIFEST.MF

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -45,6 +45,8 @@
 		<cbi-plugins.version>1.1.7</cbi-plugins.version>
 
 		<semverVersion>6.0.0</semverVersion>
+
+		<tycho.scmUrl>scm:git:https://github.com/eclipse-embed-cdt/eclipse-plugins.git</tycho.scmUrl>
 	</properties>
 
 	<licenses>
@@ -189,6 +191,25 @@
 						</configuration>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-packaging-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<dependencies>
+					<!-- Use jgit to resolve source references for git: type SCM -->
+					<dependency>
+						<groupId>org.eclipse.tycho.extras</groupId>
+						<artifactId>tycho-sourceref-jgit</artifactId>
+						<version>${tycho.version}</version>
+					</dependency>
+				</dependencies>
+				<configuration>
+					<sourceReferences>
+						<!-- Generate the source reference in the MANIFEST.MF -->
+						<generate>true</generate>
+					</sourceReferences>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>


### PR DESCRIPTION
This allows the jar files to be tracked back to their original
source. See https://wiki.eclipse.org/PDE/UI/SourceReferences