### PR TITLE
Add PATH to pyocd search path default preferences

### DIFF
--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/preferences.ini
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/preferences.ini
@@ -18,6 +18,7 @@ executable.name.osx=pyocd
 
 # Platform specific defaults.
 search.path.windows=\
+${env_var:PATH}:\
 ${user.home}/AppData/Roaming/Programs/pyOCD;\
 ${user.home}/AppData/Local/Programs/pyOCD;\
 ${user.home}/local/pyOCD;\
@@ -28,6 +29,7 @@ D:/Program Files/pyOCD;\
 D:/Program Files (x86)/pyOCD
 
 search.path.linux=\
+${env_var:PATH}:\
 ${user.home}/bin:\
 ${user.home}/local/pyocd:\
 ${user.home}/.local/pyocd:\
@@ -36,6 +38,7 @@ ${user.home}/.local/pyocd:\
 /usr/bin
 
 search.path.osx=\
+${env_var:PATH}:\
 ${user.home}/bin:\
 ${user.home}/Applications/pyOCD:\
 ${user.home}/local/pyOCD:\


### PR DESCRIPTION
This simple change makes it possible to find pyocd on PATH with only default preferences.

The older implementation that was removed in the last PR tested the resolved path, in the case it didn't find a file there, by calling out to pyocd. Then it would again call out to get probes and targets. That added an unnecessary additional external process invocation.