### PR TITLE
pyocd additional settings

### DIFF
--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/Configuration.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/Configuration.java
@@ -142,7 +142,7 @@ public class Configuration {
 					DefaultPreferences.GDB_SERVER_TELNET_PORT_NUMBER_DEFAULT)));
 
 			// Board ID
-			String boardId = configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_BOARD_ID,
+			String boardId = configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_PROBE_ID,
 					DefaultPreferences.GDB_SERVER_BOARD_ID_DEFAULT);
 			if (!boardId.isEmpty()) {
 				lst.add("--uid");

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/Configuration.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/Configuration.java
@@ -128,6 +128,9 @@ public class Configuration {
 			// disable waiting for a board to be connected
 			lst.add("--no-wait");
 
+			lst.add("-j");
+			lst.add(DebugUtils.getProjectOsPath(configuration).toOSString());
+			
 			// GDB port
 			lst.add("--port");
 			lst.add(Integer.toString(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_GDB_PORT_NUMBER,

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/Configuration.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/Configuration.java
@@ -178,13 +178,13 @@ public class Configuration {
 			int flashMode = configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_FLASH_MODE,
 					DefaultPreferences.GDB_SERVER_FLASH_MODE_DEFAULT);
 			switch (flashMode) {
-			case PreferenceConstants.AUTO_ERASE:
+			case PreferenceConstants.FlashMode.AUTO_ERASE:
 				lst.add("--erase=auto");
 				break;
-			case PreferenceConstants.CHIP_ERASE:
+			case PreferenceConstants.FlashMode.CHIP_ERASE:
 				lst.add("--erase=chip");
 				break;
-			case PreferenceConstants.SECTOR_ERASE:
+			case PreferenceConstants.FlashMode.SECTOR_ERASE:
 				lst.add("--erase=sector");
 				break;
 			}

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/Configuration.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/Configuration.java
@@ -189,10 +189,10 @@ public class Configuration {
 				break;
 			}
 
-			if (configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_FLASH_FAST_VERIFY,
-					DefaultPreferences.GDB_SERVER_FLASH_FAST_VERIFY_DEFAULT)) {
-				lst.add("--trust-crc");
-			}
+			// Smart flash
+			boolean boolValue = configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_SMART_FLASH,
+					DefaultPreferences.GDB_SERVER_SMART_FLASH_DEFAULT);
+			lst.add("-Osmart_flash=" + (boolValue ? "1" : "0"));
 
 			// Semihosting
 			if (configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_ENABLE_SEMIHOSTING,

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/Configuration.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/Configuration.java
@@ -273,7 +273,7 @@ public class Configuration {
 		// Added as a marker, it is displayed if the configuration was processed
 		// properly.
 		lst.add("-c");
-		lst.add("echo \"Started by GNU MCU Eclipse\"");
+		lst.add("echo \"" + getGdbServerStartedMessage() + "\"");
 
 		return lst.toArray(new String[0]);
 	}
@@ -412,6 +412,10 @@ public class Configuration {
 		return getDoStartGdbServer(config)
 				&& config.getAttribute(ConfigurationAttributes.DO_GDB_SERVER_ALLOCATE_SEMIHOSTING_CONSOLE,
 						DefaultPreferences.DO_GDB_SERVER_ALLOCATE_SEMIHOSTING_CONSOLE_DEFAULT);
+	}
+	
+	public static String getGdbServerStartedMessage() {
+		return "Started by Eclipse Embedded CDT"; 
 	}
 
 	// ------------------------------------------------------------------------

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/Configuration.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/Configuration.java
@@ -161,6 +161,48 @@ public class Configuration {
 			lst.add("--frequency");
 			lst.add(Integer.toString(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_BUS_SPEED,
 					DefaultPreferences.GDB_SERVER_BUS_SPEED_DEFAULT)));
+			
+			// Connect mode
+			int connectMode = configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_CONNECT_MODE,
+					DefaultPreferences.GDB_SERVER_CONNECT_MODE_DEFAULT);
+			switch (connectMode) {
+			case PreferenceConstants.ConnectMode.HALT:
+				lst.add("--connect=halt");
+				break;
+			case PreferenceConstants.ConnectMode.PRE_RESET:
+				lst.add("--connect=pre-reset");
+				break;
+			case PreferenceConstants.ConnectMode.UNDER_RESET:
+				lst.add("--connect=under-reset");
+				break;
+			case PreferenceConstants.ConnectMode.ATTACH:
+				lst.add("--connect=attach");
+				break;
+			}
+			
+			// Reset type
+			int resetType = configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_RESET_TYPE,
+					DefaultPreferences.GDB_SERVER_RESET_TYPE_DEFAULT);
+			switch (resetType) {
+			case PreferenceConstants.ResetType.DEFAULT:
+				lst.add("-Oreset_type=default");
+				break;
+			case PreferenceConstants.ResetType.HARDWARE:
+				lst.add("-Oreset_type=hw");
+				break;
+			case PreferenceConstants.ResetType.SOFTWARE_DEFAULT:
+				lst.add("-Oreset_type=sw");
+				break;
+			case PreferenceConstants.ResetType.SOFTWARE_SYSRESETREQ:
+				lst.add("-Oreset_type=sw_sysresetreq");
+				break;
+			case PreferenceConstants.ResetType.SOFTWARE_VECTRESET:
+				lst.add("-Oreset_type=sw_vectreset");
+				break;
+			case PreferenceConstants.ResetType.SOFTWARE_EMULATED:
+				lst.add("-Oreset_type=sw_emulated");
+				break;
+			}
 
 			// Halt at hard fault
 			if (configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_HALT_AT_HARD_FAULT,

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/ConfigurationAttributes.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/ConfigurationAttributes.java
@@ -40,7 +40,7 @@ public interface ConfigurationAttributes extends org.eclipse.embedcdt.debug.gdbj
 
 	public static final String GDB_SERVER_TELNET_PORT_NUMBER = PREFIX + ".gdbServerTelnetPortNumber"; //$NON-NLS-1$
 
-	public static final String GDB_SERVER_BOARD_ID = PREFIX + ".gdbServerBoardId"; //$NON-NLS-1$
+	public static final String GDB_SERVER_PROBE_ID = PREFIX + ".gdbServerBoardId"; //$NON-NLS-1$
 
 	public static final String GDB_SERVER_BOARD_NAME = PREFIX + ".gdbServerBoardName"; //$NON-NLS-1$
 

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/ConfigurationAttributes.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/ConfigurationAttributes.java
@@ -78,9 +78,6 @@ public interface ConfigurationAttributes extends org.eclipse.embedcdt.debug.gdbj
 	// ------------------------------------------------------------------------
 
 	// TabStartup
-	public static final String DO_FIRST_RESET = PREFIX + ".doFirstReset"; //$NON-NLS-1$
-	public static final String FIRST_RESET_TYPE = PREFIX + ".firstResetType"; //$NON-NLS-1$
-
 	public static final String OTHER_INIT_COMMANDS = PREFIX + ".otherInitCommands"; //$NON-NLS-1$
 
 	public static final String DO_DEBUG_IN_RAM = PREFIX + ".doDebugInRam"; //$NON-NLS-1$

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/ConfigurationAttributes.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/ConfigurationAttributes.java
@@ -56,7 +56,7 @@ public interface ConfigurationAttributes extends org.eclipse.embedcdt.debug.gdbj
 
 	public static final String GDB_SERVER_FLASH_MODE = PREFIX + ".gdbServerFlashMode"; //$NON-NLS-1$
 
-	public static final String GDB_SERVER_FLASH_FAST_VERIFY = PREFIX + ".gdbServerFlashFastVerify"; //$NON-NLS-1$
+	public static final String GDB_SERVER_SMART_FLASH = PREFIX + ".gdbServerSmartFlash"; //$NON-NLS-1$
 
 	public static final String GDB_SERVER_ENABLE_SEMIHOSTING = PREFIX + ".gdbServerEnableSemihosting"; //$NON-NLS-1$
 

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/ConfigurationAttributes.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/ConfigurationAttributes.java
@@ -50,6 +50,10 @@ public interface ConfigurationAttributes extends org.eclipse.embedcdt.debug.gdbj
 
 	public static final String GDB_SERVER_TARGET_NAME = PREFIX + ".gdbServerTargetName"; //$NON-NLS-1$
 
+	public static final String GDB_SERVER_CONNECT_MODE = PREFIX + ".gdbServerConnectMode"; //$NON-NLS-1$
+
+	public static final String GDB_SERVER_RESET_TYPE = PREFIX + ".gdbServerResetType"; //$NON-NLS-1$
+
 	public static final String GDB_SERVER_HALT_AT_HARD_FAULT = PREFIX + ".gdbServerHaltAtHardFault"; //$NON-NLS-1$
 
 	public static final String GDB_SERVER_STEP_INTO_INTERRUPTS = PREFIX + ".gdbServerStepIntoInterrutps"; //$NON-NLS-1$

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/ConfigurationAttributes.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/ConfigurationAttributes.java
@@ -81,8 +81,6 @@ public interface ConfigurationAttributes extends org.eclipse.embedcdt.debug.gdbj
 	public static final String DO_FIRST_RESET = PREFIX + ".doFirstReset"; //$NON-NLS-1$
 	public static final String FIRST_RESET_TYPE = PREFIX + ".firstResetType"; //$NON-NLS-1$
 
-	public static final String ENABLE_SEMIHOSTING = PREFIX + ".enableSemihosting"; //$NON-NLS-1$
-
 	public static final String OTHER_INIT_COMMANDS = PREFIX + ".otherInitCommands"; //$NON-NLS-1$
 
 	public static final String DO_DEBUG_IN_RAM = PREFIX + ".doDebugInRam"; //$NON-NLS-1$

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/dsf/DebuggerCommands.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/dsf/DebuggerCommands.java
@@ -109,20 +109,6 @@ public class DebuggerCommands extends GnuMcuDebuggerCommandsService {
 	@Override
 	public IStatus addFirstResetCommands(List<String> commandsList) {
 
-		if (DebugUtils.getAttribute(fAttributes, ConfigurationAttributes.DO_FIRST_RESET,
-				DefaultPreferences.DO_FIRST_RESET_DEFAULT)) {
-
-			String commandStr = DefaultPreferences.DO_FIRST_RESET_COMMAND;
-			String resetType = DebugUtils.getAttribute(fAttributes, ConfigurationAttributes.FIRST_RESET_TYPE,
-					DefaultPreferences.FIRST_RESET_TYPE_DEFAULT);
-			commandsList.add(commandStr + resetType);
-
-			// Although the manual claims that reset always does a
-			// halt, better issue it explicitly
-			commandStr = DefaultPreferences.HALT_COMMAND;
-			commandsList.add(commandStr);
-		}
-
 		String otherInits = DebugUtils.getAttribute(fAttributes, ConfigurationAttributes.OTHER_INIT_COMMANDS,
 				DefaultPreferences.OTHER_INIT_COMMANDS_DEFAULT).trim();
 

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/dsf/DebuggerCommands.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/dsf/DebuggerCommands.java
@@ -132,12 +132,6 @@ public class DebuggerCommands extends GnuMcuDebuggerCommandsService {
 		}
 		DebugUtils.addMultiLine(otherInits, commandsList);
 
-		if (DebugUtils.getAttribute(fAttributes, ConfigurationAttributes.ENABLE_SEMIHOSTING,
-				DefaultPreferences.ENABLE_SEMIHOSTING_DEFAULT)) {
-			String commandStr = DefaultPreferences.ENABLE_SEMIHOSTING_COMMAND;
-			commandsList.add(commandStr);
-		}
-
 		return Status.OK_STATUS;
 	}
 

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/dsf/GdbServerBackend.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/dsf/GdbServerBackend.java
@@ -225,12 +225,14 @@ public class GdbServerBackend extends GnuMcuGdbServerBackend {
 		return true;
 	}
 
-	public boolean matchStdErrExpectedPattern(String line) {
-		if (line.indexOf("Started by GNU ARM Eclipse") >= 0 || line.indexOf("Started by GNU MCU Eclipse") >= 0) {
-			return true;
-		}
+	public boolean matchStdOutExpectedPattern(String line) {
+		String message = Configuration.getGdbServerStartedMessage();
+		return (line.indexOf(message) >= 0);
+	}
 
-		return false;
+	public boolean matchStdErrExpectedPattern(String line) {
+		String message = Configuration.getGdbServerStartedMessage();
+		return (line.indexOf(message) >= 0);
 	}
 
 	/**

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/dsf/LaunchConfigurationDelegate.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/dsf/LaunchConfigurationDelegate.java
@@ -62,7 +62,7 @@ import org.eclipse.embedcdt.internal.debug.gdbjtag.pyocd.core.Activator;
  *
  *
  */
-@SuppressWarnings("restriction")
+@SuppressWarnings({ "restriction", "deprecation" })
 public class LaunchConfigurationDelegate extends AbstractGnuMcuLaunchConfigurationDelegate {
 
 	// ------------------------------------------------------------------------

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/preferences/DefaultPreferences.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/preferences/DefaultPreferences.java
@@ -68,9 +68,6 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 
 	public static final boolean UPDATE_THREAD_LIST_DEFAULT = false;
 
-	public static final boolean DO_FIRST_RESET_DEFAULT = false;
-	public static final String FIRST_RESET_TYPE_DEFAULT = "default";
-
 	public static final boolean DO_DEBUG_IN_RAM_DEFAULT = false;
 
 	public static final boolean DO_SECOND_RESET_DEFAULT = true;
@@ -86,7 +83,6 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 
 	// Debugger commands
 	public static final String GDB_CLIENT_OTHER_COMMANDS_DEFAULT = "set mem inaccessible-by-default off\n";
-	public static final String DO_FIRST_RESET_COMMAND = "monitor reset ";
 	public static final String HALT_COMMAND = "monitor halt";
 	public static final String DO_SECOND_RESET_COMMAND = "monitor reset ";
 	public static final String DO_CONTINUE_COMMAND = "continue";

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/preferences/DefaultPreferences.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/preferences/DefaultPreferences.java
@@ -49,6 +49,8 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 	public static final int GDB_SERVER_BUS_SPEED_DEFAULT = 1000000;
 	public static final boolean GDB_SERVER_OVERRIDE_TARGET_DEFAULT = false;
 	public static final String GDB_SERVER_TARGET_NAME_DEFAULT = ""; //$NON-NLS-1$
+	public static final int GDB_SERVER_CONNECT_MODE_DEFAULT = PreferenceConstants.ConnectMode.HALT;
+	public static final int GDB_SERVER_RESET_TYPE_DEFAULT = PreferenceConstants.ResetType.DEFAULT;
 	public static final boolean GDB_SERVER_HALT_AT_HARD_FAULT_DEFAULT = true;
 	public static final boolean GDB_SERVER_STEP_INTO_INTERRUPTS_DEFAULT = false;
 	public static final int GDB_SERVER_FLASH_MODE_DEFAULT = PreferenceConstants.FlashMode.SECTOR_ERASE;

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/preferences/DefaultPreferences.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/preferences/DefaultPreferences.java
@@ -51,7 +51,7 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 	public static final String GDB_SERVER_TARGET_NAME_DEFAULT = ""; //$NON-NLS-1$
 	public static final boolean GDB_SERVER_HALT_AT_HARD_FAULT_DEFAULT = true;
 	public static final boolean GDB_SERVER_STEP_INTO_INTERRUPTS_DEFAULT = false;
-	public static final int GDB_SERVER_FLASH_MODE_DEFAULT = PreferenceConstants.SECTOR_ERASE;
+	public static final int GDB_SERVER_FLASH_MODE_DEFAULT = PreferenceConstants.FlashMode.SECTOR_ERASE;
 	public static final boolean GDB_SERVER_FLASH_FAST_VERIFY_DEFAULT = false;
 	public static final boolean GDB_SERVER_ENABLE_SEMIHOSTING_DEFAULT = true;
 	public static final boolean GDB_SERVER_USE_GDB_SYSCALLS_DEFAULT = false;

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/preferences/DefaultPreferences.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/preferences/DefaultPreferences.java
@@ -52,7 +52,7 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 	public static final boolean GDB_SERVER_HALT_AT_HARD_FAULT_DEFAULT = true;
 	public static final boolean GDB_SERVER_STEP_INTO_INTERRUPTS_DEFAULT = false;
 	public static final int GDB_SERVER_FLASH_MODE_DEFAULT = PreferenceConstants.FlashMode.SECTOR_ERASE;
-	public static final boolean GDB_SERVER_FLASH_FAST_VERIFY_DEFAULT = false;
+	public static final boolean GDB_SERVER_SMART_FLASH_DEFAULT = true;
 	public static final boolean GDB_SERVER_ENABLE_SEMIHOSTING_DEFAULT = true;
 	public static final boolean GDB_SERVER_USE_GDB_SYSCALLS_DEFAULT = false;
 	public static final String GDB_SERVER_LOG_DEFAULT = ""; //$NON-NLS-1$

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/preferences/DefaultPreferences.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/preferences/DefaultPreferences.java
@@ -71,8 +71,6 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 	public static final boolean DO_FIRST_RESET_DEFAULT = false;
 	public static final String FIRST_RESET_TYPE_DEFAULT = "default";
 
-	public static final boolean ENABLE_SEMIHOSTING_DEFAULT = true;
-
 	public static final boolean DO_DEBUG_IN_RAM_DEFAULT = false;
 
 	public static final boolean DO_SECOND_RESET_DEFAULT = true;
@@ -90,7 +88,6 @@ public class DefaultPreferences extends org.eclipse.embedcdt.debug.gdbjtag.core.
 	public static final String GDB_CLIENT_OTHER_COMMANDS_DEFAULT = "set mem inaccessible-by-default off\n";
 	public static final String DO_FIRST_RESET_COMMAND = "monitor reset ";
 	public static final String HALT_COMMAND = "monitor halt";
-	public static final String ENABLE_SEMIHOSTING_COMMAND = "monitor arm semihosting enable";
 	public static final String DO_SECOND_RESET_COMMAND = "monitor reset ";
 	public static final String DO_CONTINUE_COMMAND = "continue";
 	public static final String OTHER_INIT_COMMANDS_DEFAULT = "";

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/preferences/PersistentPreferences.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/preferences/PersistentPreferences.java
@@ -150,29 +150,6 @@ public class PersistentPreferences extends org.eclipse.embedcdt.debug.gdbjtag.co
 		putWorkspaceString(GDB_CLIENT_COMMANDS, value);
 	}
 
-	// ----- pyOCD do initial reset -----------------------------------------
-	public boolean getPyOCDDoInitialReset() {
-
-		return Boolean.valueOf(
-				getString(GDB_PYOCD_DO_INITIAL_RESET, Boolean.toString(DefaultPreferences.DO_FIRST_RESET_DEFAULT)));
-	}
-
-	public void putPyOCDDoInitialReset(boolean value) {
-
-		putWorkspaceString(GDB_PYOCD_DO_INITIAL_RESET, Boolean.toString(value));
-	}
-
-	// ----- pyOCD initial reset type ---------------------------------------
-	public String getPyOCDInitialResetType() {
-
-		return getString(GDB_PYOCD_INITIAL_RESET_TYPE, DefaultPreferences.FIRST_RESET_TYPE_DEFAULT);
-	}
-
-	public void putPyOCDInitialResetType(String value) {
-
-		putWorkspaceString(GDB_PYOCD_INITIAL_RESET_TYPE, value);
-	}
-
 	// ----- pyOCD enable semihosting ---------------------------------------
 	public boolean getPyOCDEnableSemihosting() {
 

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/preferences/PersistentPreferences.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/preferences/PersistentPreferences.java
@@ -177,7 +177,7 @@ public class PersistentPreferences extends org.eclipse.embedcdt.debug.gdbjtag.co
 	public boolean getPyOCDEnableSemihosting() {
 
 		return Boolean.valueOf(getString(GDB_PYOCD_ENABLE_SEMIHOSTING,
-				Boolean.toString(DefaultPreferences.ENABLE_SEMIHOSTING_DEFAULT)));
+				Boolean.toString(DefaultPreferences.GDB_SERVER_ENABLE_SEMIHOSTING_DEFAULT)));
 	}
 
 	public void putPyOCDEnableSemihosting(boolean value) {

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/preferences/PreferenceConstants.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/preferences/PreferenceConstants.java
@@ -26,5 +26,20 @@ public interface PreferenceConstants {
 		public static final int SECTOR_ERASE = 2;
 		public static final int FAST_PROGRAM = 3;
 	}
+	
+	public static final class ConnectMode {
+		public static final int HALT = 0;
+		public static final int PRE_RESET = 1;
+		public static final int UNDER_RESET = 2;
+		public static final int ATTACH = 3;
+	}
 
+	public static final class ResetType {
+		public static final int DEFAULT = 0;
+		public static final int HARDWARE = 1;
+		public static final int SOFTWARE_DEFAULT = 2;
+		public static final int SOFTWARE_SYSRESETREQ = 3;
+		public static final int SOFTWARE_VECTRESET = 4;
+		public static final int SOFTWARE_EMULATED = 5;
+	}
 }

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/preferences/PreferenceConstants.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/core/preferences/PreferenceConstants.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2013 Liviu Ionescu.
- * Copyright (c) 2015-2016 Chris Reed.
+ * Copyright (c) 2015-2020 Chris Reed.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -20,9 +20,11 @@ public interface PreferenceConstants {
 
 	public static final String DEFAULT_GDB_COMMAND = "arm-none-eabi-gdb"; //$NON-NLS-1$
 
-	public static final int AUTO_ERASE = 0;
-	public static final int CHIP_ERASE = 1;
-	public static final int SECTOR_ERASE = 2;
-	public static final int FAST_PROGRAM = 3;
+	public static final class FlashMode {
+		public static final int AUTO_ERASE = 0;
+		public static final int CHIP_ERASE = 1;
+		public static final int SECTOR_ERASE = 2;
+		public static final int FAST_PROGRAM = 3;
+	}
 
 }

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabDebugger.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabDebugger.java
@@ -134,7 +134,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 	private Button fGdbServerStepIntoInterrupts;
 
 	private Combo fGdbServerFlashMode;
-	private Button fGdbServerFlashFastVerify;
+	private Button fGdbServerSmartFlash;
 
 	private Button fGdbServerEnableSemihosting;
 	private Button fGdbServerUseGdbSyscallsForSemihosting;
@@ -502,15 +502,15 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 					});
 			fGdbServerFlashMode.select(0);
 
-			fGdbServerFlashFastVerify = new Button(comp, SWT.CHECK);
-			fGdbServerFlashFastVerify.setText(Messages.getString("DebuggerTab.gdbServerFlashFastVerify_Label"));
-			fGdbServerFlashFastVerify
-					.setToolTipText(Messages.getString("DebuggerTab.gdbServerFlashFastVerify_ToolTipText"));
+			fGdbServerSmartFlash = new Button(comp, SWT.CHECK);
+			fGdbServerSmartFlash.setText(Messages.getString("DebuggerTab.gdbServerSmartFlash_Label"));
+			fGdbServerSmartFlash
+					.setToolTipText(Messages.getString("DebuggerTab.gdbServerSmartFlash_ToolTipText"));
 			gd = new GridData();
 
 			gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns - 2;
 			gd.horizontalIndent = COLUMN_PAD;
-			fGdbServerFlashFastVerify.setLayoutData(gd);
+			fGdbServerSmartFlash.setLayoutData(gd);
 		}
 
 		// Composite for next four checkboxes. Will render using two columns
@@ -702,7 +702,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 
 		fGdbServerFlashMode.addModifyListener(scheduleUpdateJobModifyListener);
 
-		fGdbServerFlashFastVerify.addSelectionListener(scheduleUpdateJobSelectionAdapter);
+		fGdbServerSmartFlash.addSelectionListener(scheduleUpdateJobSelectionAdapter);
 
 		fGdbServerEnableSemihosting.addSelectionListener(scheduleUpdateJobSelectionAdapter);
 
@@ -951,7 +951,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 		fGdbServerEnableSemihosting.setEnabled(enabled);
 		fGdbServerUseGdbSyscallsForSemihosting.setEnabled(enabled);
 		fGdbServerFlashMode.setEnabled(enabled);
-		fGdbServerFlashFastVerify.setEnabled(enabled);
+		fGdbServerSmartFlash.setEnabled(enabled);
 
 		fDoGdbServerAllocateConsole.setEnabled(enabled);
 		fDoGdbServerAllocateSemihostingConsole.setEnabled(enabled);
@@ -1431,9 +1431,9 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 				fGdbServerFlashMode.select(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_FLASH_MODE,
 						DefaultPreferences.GDB_SERVER_FLASH_MODE_DEFAULT));
 
-				fGdbServerFlashFastVerify
-						.setSelection(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_FLASH_FAST_VERIFY,
-								DefaultPreferences.GDB_SERVER_FLASH_FAST_VERIFY_DEFAULT));
+				fGdbServerSmartFlash
+						.setSelection(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_SMART_FLASH,
+								DefaultPreferences.GDB_SERVER_SMART_FLASH_DEFAULT));
 
 				// Semihosting
 				booleanDefault = fPersistentPreferences.getPyOCDEnableSemihosting();
@@ -1566,7 +1566,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 			// Flash
 			fGdbServerFlashMode.select(DefaultPreferences.GDB_SERVER_FLASH_MODE_DEFAULT);
 
-			fGdbServerFlashFastVerify.setSelection(DefaultPreferences.GDB_SERVER_FLASH_FAST_VERIFY_DEFAULT);
+			fGdbServerSmartFlash.setSelection(DefaultPreferences.GDB_SERVER_SMART_FLASH_DEFAULT);
 
 			// Semihosting
 			fGdbServerEnableSemihosting.setSelection(DefaultPreferences.GDB_SERVER_ENABLE_SEMIHOSTING_DEFAULT);
@@ -1804,8 +1804,8 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_FLASH_MODE,
 					fGdbServerFlashMode.getSelectionIndex());
 
-			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_FLASH_FAST_VERIFY,
-					fGdbServerFlashFastVerify.getSelection());
+			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_SMART_FLASH,
+					fGdbServerSmartFlash.getSelection());
 
 			// Semihosting
 			booleanValue = fGdbServerEnableSemihosting.getSelection();
@@ -1961,8 +1961,8 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_FLASH_MODE,
 					DefaultPreferences.GDB_SERVER_FLASH_MODE_DEFAULT);
 
-			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_FLASH_FAST_VERIFY,
-					DefaultPreferences.GDB_SERVER_FLASH_FAST_VERIFY_DEFAULT);
+			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_SMART_FLASH,
+					DefaultPreferences.GDB_SERVER_SMART_FLASH_DEFAULT);
 
 			// Semihosting
 			defaultBoolean = fPersistentPreferences.getPyOCDEnableSemihosting();

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabDebugger.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabDebugger.java
@@ -494,9 +494,12 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 			gd = new GridData();
 			gd.widthHint = 120;
 			fGdbServerFlashMode.setLayoutData(gd);
-			fGdbServerFlashMode.setItems(new String[] { Messages.getString("DebuggerTab.gdbServerFlashMode.AutoErase"),
+			// Note: the index of these items must match the PreferenceConstants.FlashMode constants.
+			fGdbServerFlashMode.setItems(new String[] {
+					Messages.getString("DebuggerTab.gdbServerFlashMode.AutoErase"),
 					Messages.getString("DebuggerTab.gdbServerFlashMode.ChipErase"),
-					Messages.getString("DebuggerTab.gdbServerFlashMode.SectorErase"), });
+					Messages.getString("DebuggerTab.gdbServerFlashMode.SectorErase"),
+					});
 			fGdbServerFlashMode.select(0);
 
 			fGdbServerFlashFastVerify = new Button(comp, SWT.CHECK);

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabDebugger.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabDebugger.java
@@ -445,6 +445,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 			Composite local = createHorizontalLayout(comp, 2, 1);
 			{
 				fGdbServerProbeId = new Combo(local, SWT.DROP_DOWN | SWT.READ_ONLY);
+				fGdbServerProbeId.setToolTipText(Messages.getString("DebuggerTab.gdbServerProbeId_ToolTipText"));
 				GridData gd = new GridData(GridData.FILL_HORIZONTAL);
 				fGdbServerProbeId.setLayoutData(gd);
 				fGdbServerProbeId.setItems(new String[] {});
@@ -489,8 +490,9 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 			label.setToolTipText(Messages.getString("DebuggerTab.gdbServerBusSpeed_ToolTipText"));
 
 			fGdbServerBusSpeed = new Combo(comp, SWT.DROP_DOWN);
+			fGdbServerBusSpeed.setToolTipText(Messages.getString("DebuggerTab.gdbServerBusSpeed_ToolTipText"));
 			GridData gd = new GridData();
-			gd.widthHint = 120;
+			gd.widthHint = 200;
 			fGdbServerBusSpeed.setLayoutData(gd);
 			fGdbServerBusSpeed.setItems(new String[] { "1000000", "2000000", "8000000", "12000000" });
 			fGdbServerBusSpeed.select(0);
@@ -510,8 +512,9 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 			label.setLayoutData(gd);
 
 			fGdbServerConnectMode = new Combo(comp, SWT.DROP_DOWN | SWT.READ_ONLY);
+			fGdbServerConnectMode.setToolTipText(Messages.getString("DebuggerTab.gdbServerConnectMode_ToolTipText"));
 			gd = new GridData();
-			gd.widthHint = 120;
+			gd.widthHint = 200;
 			gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns - 1;
 			fGdbServerConnectMode.setLayoutData(gd);
 			// Note: the index of these items must match the PreferenceConstants.ConnectMode constants.
@@ -532,8 +535,9 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 			label.setLayoutData(gd);
 
 			fGdbServerResetType = new Combo(comp, SWT.DROP_DOWN | SWT.READ_ONLY);
+			fGdbServerResetType.setToolTipText(Messages.getString("DebuggerTab.gdbServerResetType_ToolTipText"));
 			gd = new GridData();
-			gd.widthHint = 120;
+			gd.widthHint = 200;
 			gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns - 1;
 			fGdbServerResetType.setLayoutData(gd);
 			// Note: the index of these items must match the PreferenceConstants.ResetType constants.
@@ -556,8 +560,9 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 			label.setLayoutData(gd);
 
 			fGdbServerFlashMode = new Combo(comp, SWT.DROP_DOWN | SWT.READ_ONLY);
+			fGdbServerFlashMode.setToolTipText(Messages.getString("DebuggerTab.gdbServerFlashMode_ToolTipText"));
 			gd = new GridData();
-			gd.widthHint = 120;
+			gd.widthHint = 200;
 			fGdbServerFlashMode.setLayoutData(gd);
 			// Note: the index of these items must match the PreferenceConstants.FlashMode constants.
 			fGdbServerFlashMode.setItems(new String[] {
@@ -632,6 +637,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 			label.setLayoutData(gd);
 
 			fGdbServerOtherOptions = new Text(comp, SWT.MULTI | SWT.WRAP | SWT.BORDER | SWT.V_SCROLL);
+			fGdbServerOtherOptions.setToolTipText(Messages.getString("DebuggerTab.gdbServerOther_ToolTipText"));
 			gd = new GridData(SWT.FILL, SWT.FILL, true, true);
 			gd.heightHint = 60;
 			gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns - 1;

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabDebugger.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabDebugger.java
@@ -102,7 +102,8 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 
 	private List<PyOCD.Probe> fProbes;
 	private String fSelectedProbeId;
-	private boolean fProbeIdListHasUnavailableItem; //!< Whether the probes list includes an item for the probe in the config that is not currently connected.
+	//! Whether the probes list includes an item for the probe in the config that is not currently connected.
+	private boolean fProbeIdListHasUnavailableItem;
 	private String fProbeIdListUnavailableId; //!< Probe ID for the unavailable item.
 	private Map<String, PyOCD.Target> fTargetsByPartNumber; //!< Maps part number (user friendly name) to target object.
 	private Map<String, PyOCD.Target> fTargetsByName; //!< Maps target name to target object.
@@ -1339,7 +1340,8 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 									// Check again to make sure we haven't been disposed.
 									if (getControl().isDisposed()) {
 										if (Activator.getInstance().isDebugging()) {
-											System.out.printf("(probes, from UI job) bailing on updating debugger tab because it has been disposed\n");
+											System.out.printf("(probes, from UI job) bailing on updating debugger tab '"
+													+ "because it has been disposed\n");
 										}
 										return Status.OK_STATUS;
 									}
@@ -1401,7 +1403,8 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 
 							if (getControl().isDisposed()) {
 								if (Activator.getInstance().isDebugging()) {
-									System.out.printf("(targets) bailing on updating debugger tab because it has been disposed\n");
+									System.out.printf("(targets) bailing on updating debugger tab because it "
+											+ "has been disposed\n");
 								}
 								return;
 							}
@@ -1448,7 +1451,8 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 									// Check again to make sure we haven't been disposed.
 									if (getControl().isDisposed()) {
 										if (Activator.getInstance().isDebugging()) {
-											System.out.printf("(targets, from UI job) bailing on updating debugger tab because it has been disposed\n");
+											System.out.printf("(targets, from UI job) bailing on updating "
+													+ "debugger tab because it has been disposed\n");
 										}
 										return Status.OK_STATUS;
 									}

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabDebugger.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabDebugger.java
@@ -1433,9 +1433,10 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 								DefaultPreferences.GDB_SERVER_FLASH_FAST_VERIFY_DEFAULT));
 
 				// Semihosting
+				booleanDefault = fPersistentPreferences.getPyOCDEnableSemihosting();
 				fGdbServerEnableSemihosting
 						.setSelection(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_ENABLE_SEMIHOSTING,
-								DefaultPreferences.GDB_SERVER_ENABLE_SEMIHOSTING_DEFAULT));
+								booleanDefault));
 
 				fGdbServerUseGdbSyscallsForSemihosting
 						.setSelection(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_USE_GDB_SYSCALLS,
@@ -1804,8 +1805,10 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 					fGdbServerFlashFastVerify.getSelection());
 
 			// Semihosting
+			booleanValue = fGdbServerEnableSemihosting.getSelection();
 			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_ENABLE_SEMIHOSTING,
-					fGdbServerEnableSemihosting.getSelection());
+					booleanValue);
+			fPersistentPreferences.putPyOCDEnableSemihosting(booleanValue);
 
 			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_USE_GDB_SYSCALLS,
 					fGdbServerUseGdbSyscallsForSemihosting.getSelection());
@@ -1959,8 +1962,9 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 					DefaultPreferences.GDB_SERVER_FLASH_FAST_VERIFY_DEFAULT);
 
 			// Semihosting
+			defaultBoolean = fPersistentPreferences.getPyOCDEnableSemihosting();
 			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_ENABLE_SEMIHOSTING,
-					DefaultPreferences.GDB_SERVER_ENABLE_SEMIHOSTING_DEFAULT);
+					defaultBoolean);
 
 			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_USE_GDB_SYSCALLS,
 					DefaultPreferences.GDB_SERVER_USE_GDB_SYSCALLS_DEFAULT);

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabDebugger.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabDebugger.java
@@ -129,6 +129,9 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 	private Combo fGdbServerTargetName;
 
 	private Combo fGdbServerBusSpeed;
+	
+	private Combo fGdbServerConnectMode;
+	private Combo fGdbServerResetType;
 
 	private Button fGdbServerHaltAtHardFault;
 	private Button fGdbServerStepIntoInterrupts;
@@ -485,6 +488,52 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 
 		{
 			Label label = new Label(comp, SWT.NONE);
+			label.setText(Messages.getString("DebuggerTab.gdbServerConnectMode_Label")); //$NON-NLS-1$
+			label.setToolTipText(Messages.getString("DebuggerTab.gdbServerConnectMode_ToolTipText"));
+			GridData gd = new GridData();
+			label.setLayoutData(gd);
+
+			fGdbServerConnectMode = new Combo(comp, SWT.DROP_DOWN | SWT.READ_ONLY);
+			gd = new GridData();
+			gd.widthHint = 120;
+			gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns - 1;
+			fGdbServerConnectMode.setLayoutData(gd);
+			// Note: the index of these items must match the PreferenceConstants.ConnectMode constants.
+			fGdbServerConnectMode.setItems(new String[] {
+					Messages.getString("DebuggerTab.gdbServerConnectMode.Halt"),
+					Messages.getString("DebuggerTab.gdbServerConnectMode.PreReset"),
+					Messages.getString("DebuggerTab.gdbServerConnectMode.UnderReset"),
+					Messages.getString("DebuggerTab.gdbServerConnectMode.Attach"),
+					});
+			fGdbServerConnectMode.select(0);
+		}
+
+		{
+			Label label = new Label(comp, SWT.NONE);
+			label.setText(Messages.getString("DebuggerTab.gdbServerResetType_Label")); //$NON-NLS-1$
+			label.setToolTipText(Messages.getString("DebuggerTab.gdbServerResetType_ToolTipText"));
+			GridData gd = new GridData();
+			label.setLayoutData(gd);
+
+			fGdbServerResetType = new Combo(comp, SWT.DROP_DOWN | SWT.READ_ONLY);
+			gd = new GridData();
+			gd.widthHint = 120;
+			gd.horizontalSpan = ((GridLayout) comp.getLayout()).numColumns - 1;
+			fGdbServerResetType.setLayoutData(gd);
+			// Note: the index of these items must match the PreferenceConstants.ResetType constants.
+			fGdbServerResetType.setItems(new String[] {
+					Messages.getString("DebuggerTab.gdbServerResetType.Default"),
+					Messages.getString("DebuggerTab.gdbServerResetType.Hardware"),
+					Messages.getString("DebuggerTab.gdbServerResetType.SoftwareDefault"),
+					Messages.getString("DebuggerTab.gdbServerResetType.SoftwareSysResetReq"),
+					Messages.getString("DebuggerTab.gdbServerResetType.SoftwareVectReset"),
+					Messages.getString("DebuggerTab.gdbServerResetType.SoftwareEmulated"),
+					});
+			fGdbServerResetType.select(0);
+		}
+
+		{
+			Label label = new Label(comp, SWT.NONE);
 			label.setText(Messages.getString("DebuggerTab.gdbServerFlashMode_Label")); //$NON-NLS-1$
 			label.setToolTipText(Messages.getString("DebuggerTab.gdbServerFlashMode_ToolTipText"));
 			GridData gd = new GridData();
@@ -695,6 +744,10 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 		fGdbServerBusSpeed.addModifyListener(scheduleUpdateJobModifyListener);
 
 		fGdbServerTargetName.addModifyListener(scheduleUpdateJobModifyListener);
+
+		fGdbServerConnectMode.addModifyListener(scheduleUpdateJobModifyListener);
+
+		fGdbServerResetType.addModifyListener(scheduleUpdateJobModifyListener);
 
 		fGdbServerHaltAtHardFault.addSelectionListener(scheduleUpdateJobSelectionAdapter);
 
@@ -946,6 +999,8 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 		fGdbServerBusSpeed.setEnabled(enabled);
 		fGdbServerOverrideTarget.setEnabled(enabled);
 		fGdbServerTargetName.setEnabled(enabled && fGdbServerOverrideTarget.getSelection());
+		fGdbServerConnectMode.setEnabled(enabled);
+		fGdbServerResetType.setEnabled(enabled);
 		fGdbServerHaltAtHardFault.setEnabled(enabled);
 		fGdbServerStepIntoInterrupts.setEnabled(enabled);
 		fGdbServerEnableSemihosting.setEnabled(enabled);
@@ -1417,6 +1472,14 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 								DefaultPreferences.GDB_SERVER_OVERRIDE_TARGET_DEFAULT));
 
 				fGdbServerTargetName.setText(""); // will be updated with updateTargets() call below. 
+				
+				// Connect mode
+				fGdbServerConnectMode.select(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_CONNECT_MODE,
+						DefaultPreferences.GDB_SERVER_CONNECT_MODE_DEFAULT));
+				
+				// Reset type
+				fGdbServerResetType.select(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_RESET_TYPE,
+						DefaultPreferences.GDB_SERVER_RESET_TYPE_DEFAULT));
 
 				// Misc options
 				fGdbServerHaltAtHardFault
@@ -1557,6 +1620,12 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 			fGdbServerOverrideTarget.setSelection(DefaultPreferences.GDB_SERVER_OVERRIDE_TARGET_DEFAULT);
 
 			fGdbServerTargetName.setText(DefaultPreferences.GDB_SERVER_TARGET_NAME_DEFAULT);
+			
+			// Connect mode
+			fGdbServerConnectMode.select(DefaultPreferences.GDB_SERVER_CONNECT_MODE_DEFAULT);
+			
+			// Reset type
+			fGdbServerResetType.select(DefaultPreferences.GDB_SERVER_RESET_TYPE_DEFAULT);
 
 			// Misc options
 			fGdbServerHaltAtHardFault.setSelection(DefaultPreferences.GDB_SERVER_HALT_AT_HARD_FAULT_DEFAULT);
@@ -1793,6 +1862,14 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 				configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_TARGET_NAME, targetName);
 			}
 
+			// Connect mode
+			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_CONNECT_MODE,
+					fGdbServerConnectMode.getSelectionIndex());
+
+			// Reset type
+			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_RESET_TYPE,
+					fGdbServerResetType.getSelectionIndex());
+
 			// Misc options
 			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_HALT_AT_HARD_FAULT,
 					fGdbServerHaltAtHardFault.getSelection());
@@ -1949,6 +2026,12 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 
 			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_TARGET_NAME,
 					DefaultPreferences.GDB_SERVER_TARGET_NAME_DEFAULT);
+
+			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_CONNECT_MODE,
+					DefaultPreferences.GDB_SERVER_CONNECT_MODE_DEFAULT);
+
+			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_RESET_TYPE,
+					DefaultPreferences.GDB_SERVER_RESET_TYPE_DEFAULT);
 
 			// Misc options
 			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_HALT_AT_HARD_FAULT,

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabDebugger.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabDebugger.java
@@ -1299,7 +1299,6 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 							}
 							else {
 								clearPyocdErrors(true);
-								setMessage(null);
 
 								assert(probes != null);
 
@@ -1355,8 +1354,9 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 									fProbes = probes;
 
 									selectActiveProbe();
-									
-									updatePyocdLoadingMessage();
+
+									updatePyocdLoadingMessage();									
+									scheduleUpdateJob();
 									
 									return Status.OK_STATUS;
 								}
@@ -1431,7 +1431,6 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 							}
 							else {
 								clearPyocdErrors(false);
-								setMessage(null);
 							
 								List<PyOCD.Target> targets = getData();
 								assert(targets != null);
@@ -1471,12 +1470,12 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 									// Select current target from config.
 									selectActiveTarget();
 									
-									scheduleUpdateJob();
 									if (fNeedsDefaultTargetNameRefresh) {
 										selectActiveProbe();
 									}
 									
 									updatePyocdLoadingMessage();									
+									scheduleUpdateJob();
 									
 									return Status.OK_STATUS;
 								}

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabDebugger.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabDebugger.java
@@ -1407,7 +1407,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 								DefaultPreferences.GDB_SERVER_TELNET_PORT_NUMBER_DEFAULT)));
 
 				// Probe ID
-				fSelectedProbeId = configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_BOARD_ID,
+				fSelectedProbeId = configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_PROBE_ID,
 						DefaultPreferences.GDB_SERVER_BOARD_ID_DEFAULT);
 				// active probe will be selected after updateProbes() runs.
 
@@ -1769,7 +1769,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 
 			// Probe ID
 			if (fSelectedProbeId != null) {
-				configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_BOARD_ID, fSelectedProbeId);
+				configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_PROBE_ID, fSelectedProbeId);
 			}
 
 			// Target override
@@ -1933,7 +1933,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 					DefaultPreferences.GDB_SERVER_TELNET_PORT_NUMBER_DEFAULT);
 
 			// Probe ID
-			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_BOARD_ID,
+			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_PROBE_ID,
 					DefaultPreferences.GDB_SERVER_BOARD_ID_DEFAULT);
 
 			configuration.setAttribute(ConfigurationAttributes.GDB_SERVER_BOARD_NAME,

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabStartup.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabStartup.java
@@ -77,9 +77,6 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 	// Button doReset;
 	// Button doHalt;
 
-	private Button fDoFirstReset;
-	private Text fFirstResetType;
-
 	private Button fDoSecondReset;
 	private Text fSecondResetType;
 	private Label fSecondResetWarning;
@@ -234,46 +231,12 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 		}
 
 		{
-			Composite local = new Composite(comp, SWT.NONE);
-			GridLayout layout = new GridLayout();
-			layout.numColumns = 3;
-			layout.marginHeight = 0;
-			layout.marginWidth = 0;
-			local.setLayout(layout);
-			// local.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-
-			fDoFirstReset = new Button(local, SWT.CHECK);
-			fDoFirstReset.setText(Messages.getString("StartupTab.doFirstReset_Text"));
-			fDoFirstReset.setToolTipText(Messages.getString("StartupTab.doFirstReset_ToolTipText"));
-
-			Label label = new Label(local, SWT.NONE);
-			label.setText(Messages.getString("StartupTab.firstResetType_Text"));
-			label.setToolTipText(Messages.getString("StartupTab.firstResetType_ToolTipText"));
-
-			fFirstResetType = new Text(local, SWT.BORDER);
-			fFirstResetType.setToolTipText(Messages.getString("StartupTab.firstResetType_ToolTipText"));
-			GridData gd = new GridData();
-			gd.widthHint = 30;
-			fFirstResetType.setLayoutData(gd);
-		}
-
-		{
 			fInitCommands = new Text(comp, SWT.MULTI | SWT.WRAP | SWT.BORDER | SWT.V_SCROLL);
 			fInitCommands.setToolTipText(Messages.getString("StartupTab.initCommands_ToolTipText"));
 			GridData gd = new GridData(GridData.FILL_BOTH);
 			gd.heightHint = 60;
 			fInitCommands.setLayoutData(gd);
 		}
-
-		// Actions
-		fDoFirstReset.addSelectionListener(new SelectionAdapter() {
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-				// doResetChanged();
-				doFirstResetChanged();
-				scheduleUpdateJob(); // updateLaunchConfigurationDialog();
-			}
-		});
 
 		ModifyListener scheduleUpdateJobModifyListener = new ModifyListener() {
 			@Override
@@ -282,16 +245,7 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 			}
 		};
 
-		fFirstResetType.addModifyListener(scheduleUpdateJobModifyListener);
-
 		fInitCommands.addModifyListener(scheduleUpdateJobModifyListener);
-	}
-
-	private void doFirstResetChanged() {
-
-		boolean enabled = fDoFirstReset.getSelection();
-
-		fFirstResetType.setEnabled(enabled);
 	}
 
 	private void createLoadGroup(Composite parent) {
@@ -853,16 +807,6 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 
 			// Initialisation Commands
 			{
-				// Do initial reset
-				booleanDefault = fPersistentPreferences.getPyOCDDoInitialReset();
-				fDoFirstReset.setSelection(
-						configuration.getAttribute(ConfigurationAttributes.DO_FIRST_RESET, booleanDefault));
-
-				// Reset type
-				stringDefault = fPersistentPreferences.getPyOCDInitialResetType();
-				fFirstResetType
-						.setText(configuration.getAttribute(ConfigurationAttributes.FIRST_RESET_TYPE, stringDefault));
-
 				// Other commands
 				stringDefault = fPersistentPreferences.getPyOCDInitOther();
 				fInitCommands.setText(
@@ -950,8 +894,6 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 						DefaultPreferences.DO_CONTINUE_DEFAULT));
 			}
 
-			doFirstResetChanged();
-
 			doSecondResetChanged();
 			loadExecutableChanged();
 			loadSymbolsChanged();
@@ -977,12 +919,6 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 
 		// Initialisation Commands
 		{
-			// Do initial reset
-			fDoFirstReset.setSelection(DefaultPreferences.DO_FIRST_RESET_DEFAULT);
-
-			// Reset type
-			fFirstResetType.setText(DefaultPreferences.FIRST_RESET_TYPE_DEFAULT);
-
 			// Other commands
 			fInitCommands.setText(DefaultPreferences.OTHER_INIT_COMMANDS_DEFAULT);
 		}
@@ -1034,8 +970,6 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 			fDoContinue.setSelection(DefaultPreferences.DO_CONTINUE_DEFAULT);
 		}
 
-		doFirstResetChanged();
-
 		doSecondResetChanged();
 		loadExecutableChanged();
 		loadSymbolsChanged();
@@ -1071,16 +1005,6 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 
 		// Initialisation Commands
 		{
-			// Do first reset
-			booleanValue = fDoFirstReset.getSelection();
-			configuration.setAttribute(ConfigurationAttributes.DO_FIRST_RESET, booleanValue);
-			fPersistentPreferences.putPyOCDDoInitialReset(booleanValue);
-
-			// First reset type
-			stringValue = fFirstResetType.getText().trim();
-			configuration.setAttribute(ConfigurationAttributes.FIRST_RESET_TYPE, stringValue);
-			fPersistentPreferences.putPyOCDInitialResetType(stringValue);
-
 			// Other commands
 			stringValue = fInitCommands.getText().trim();
 			configuration.setAttribute(ConfigurationAttributes.OTHER_INIT_COMMANDS, stringValue);
@@ -1158,12 +1082,6 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 		boolean defaultBoolean;
 
 		// Initialisation Commands
-		defaultBoolean = fPersistentPreferences.getPyOCDDoInitialReset();
-		configuration.setAttribute(ConfigurationAttributes.DO_FIRST_RESET, defaultBoolean);
-
-		defaultString = fPersistentPreferences.getPyOCDInitialResetType();
-		configuration.setAttribute(ConfigurationAttributes.FIRST_RESET_TYPE, defaultString);
-
 		defaultString = fPersistentPreferences.getPyOCDInitOther();
 		configuration.setAttribute(ConfigurationAttributes.OTHER_INIT_COMMANDS, defaultString);
 

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabStartup.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabStartup.java
@@ -84,8 +84,6 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 	private Text fSecondResetType;
 	private Label fSecondResetWarning;
 
-	private Button fEnableSemihosting;
-
 	private Button fLoadExecutable;
 	private Text fImageFileName;
 	private Button fImageFileBrowseWs;
@@ -267,20 +265,6 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 			fInitCommands.setLayoutData(gd);
 		}
 
-		{
-			Composite local = new Composite(comp, SWT.NONE);
-			GridLayout layout = new GridLayout();
-			layout.numColumns = 1;
-			layout.marginHeight = 0;
-			layout.marginWidth = 0;
-			local.setLayout(layout);
-			// local.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-
-			fEnableSemihosting = new Button(local, SWT.CHECK);
-			fEnableSemihosting.setText(Messages.getString("StartupTab.enableSemihosting_Text"));
-			fEnableSemihosting.setToolTipText(Messages.getString("StartupTab.enableSemihosting_ToolTipText"));
-		}
-
 		// Actions
 		fDoFirstReset.addSelectionListener(new SelectionAdapter() {
 			@Override
@@ -301,13 +285,6 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 		fFirstResetType.addModifyListener(scheduleUpdateJobModifyListener);
 
 		fInitCommands.addModifyListener(scheduleUpdateJobModifyListener);
-
-		fEnableSemihosting.addSelectionListener(new SelectionAdapter() {
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-				scheduleUpdateJob();
-			}
-		});
 	}
 
 	private void doFirstResetChanged() {
@@ -886,11 +863,6 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 				fFirstResetType
 						.setText(configuration.getAttribute(ConfigurationAttributes.FIRST_RESET_TYPE, stringDefault));
 
-				// Enable semihosting
-				booleanDefault = fPersistentPreferences.getPyOCDEnableSemihosting();
-				fEnableSemihosting.setSelection(
-						configuration.getAttribute(ConfigurationAttributes.ENABLE_SEMIHOSTING, booleanDefault));
-
 				// Other commands
 				stringDefault = fPersistentPreferences.getPyOCDInitOther();
 				fInitCommands.setText(
@@ -1011,9 +983,6 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 			// Reset type
 			fFirstResetType.setText(DefaultPreferences.FIRST_RESET_TYPE_DEFAULT);
 
-			// Enable semihosting
-			fEnableSemihosting.setSelection(DefaultPreferences.ENABLE_SEMIHOSTING_DEFAULT);
-
 			// Other commands
 			fInitCommands.setText(DefaultPreferences.OTHER_INIT_COMMANDS_DEFAULT);
 		}
@@ -1116,11 +1085,6 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 			stringValue = fInitCommands.getText().trim();
 			configuration.setAttribute(ConfigurationAttributes.OTHER_INIT_COMMANDS, stringValue);
 			fPersistentPreferences.putPyOCDInitOther(stringValue);
-
-			// Enable semihosting
-			booleanValue = fEnableSemihosting.getSelection();
-			configuration.setAttribute(ConfigurationAttributes.ENABLE_SEMIHOSTING, booleanValue);
-			fPersistentPreferences.putPyOCDEnableSemihosting(booleanValue);
 		}
 
 		// Load Symbols & Image...
@@ -1199,9 +1163,6 @@ public class TabStartup extends AbstractLaunchConfigurationTab {
 
 		defaultString = fPersistentPreferences.getPyOCDInitialResetType();
 		configuration.setAttribute(ConfigurationAttributes.FIRST_RESET_TYPE, defaultString);
-
-		defaultBoolean = fPersistentPreferences.getPyOCDEnableSemihosting();
-		configuration.setAttribute(ConfigurationAttributes.ENABLE_SEMIHOSTING, defaultBoolean);
 
 		defaultString = fPersistentPreferences.getPyOCDInitOther();
 		configuration.setAttribute(ConfigurationAttributes.OTHER_INIT_COMMANDS, defaultString);

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/pyocd/ui/messages.properties
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/pyocd/ui/messages.properties
@@ -14,6 +14,7 @@
 #               - API generalization to become transport-independent (e.g. to
 #                 allow connections via serial ports and pipes).
 #   Liviu Ionescu - Arm version
+#	Chris Reed - pyocd updates
 ###############################################################################
 
 
@@ -85,13 +86,13 @@ DebuggerTab.gdbServerLogBrowse_Title=Select where to store the log file
 
 DebuggerTab.gdbServerBusSpeed_Label=Bus speed:
 DebuggerTab.gdbServerBusSpeed_ToolTipText=\
-The SWD/JTAG bus frequency
+The SWD/JTAG bus frequency in Hertz.
 
 DebuggerTab.gdbServerBusSpeedUnits_Label=Hz
 
 DebuggerTab.gdbServerOverrideTarget_Label=Override target:
 DebuggerTab.gdbServerOverrideTarget_ToolTipText=\
-When enabled, the target device type is set to the item selected \
+When enabled, the target device type is set to the target type selected \
 with the combo box. If not enabled, the default target type \
 shown above is used. Setting the target type is required when using \
 standalone debug probes or on-board probes types such as J-Link \
@@ -103,7 +104,9 @@ target type. A custom value may also be entered in the field; this must \
 be the short target type name like those shown in parentheses in \
 the pull-down menu. Setting the target type is required when using \
 standalone debug probes or on-board probes types such as J-Link \
-that do not report the connected target type.
+that do not report the connected target type.\
+To install more targets, use the 'pyocd pack' subcommand from the \
+command line.
 
 DebuggerTab.gdbServerDefaultTargetType_Label=Default target:
 DebuggerTab.gdbServerDefaultTargetType_ToolTipText=\
@@ -112,7 +115,16 @@ setting is not enabled.
 
 DebuggerTab.gdbServerConnectMode_Label=Connect mode:
 DebuggerTab.gdbServerConnectMode_ToolTipText=\
-Select how pyocd connects to the target.
+Select how pyocd connects to the target.\n\n\
+"Halt": Stop all cores after connecting.\n\
+"Pre-reset": Like "Halt", but issue a hardware reset before connecting.\n\
+"Under reset": Like "Halt", but hold hardware reset asserted during the \
+connect sequence. This is often required to gain control of devices that \
+are in low power states or powered down. Not all devices support connecting \ 
+under reset.\n\
+"Attach": Connect to a running system without disturbing it or stopping \
+any cores. This only makes sense if you also configure the Startup tab \
+to not load code and disable the pre-run reset.\n
 
 DebuggerTab.gdbServerConnectMode.Halt=Halt
 DebuggerTab.gdbServerConnectMode.PreReset=Pre-reset
@@ -121,14 +133,22 @@ DebuggerTab.gdbServerConnectMode.Attach=Attach
 
 DebuggerTab.gdbServerResetType_Label=Reset type:
 DebuggerTab.gdbServerResetType_ToolTipText=\
-Method used to reset the target.
+Method used to reset the target. Not all reset types are applicable \
+to all devices.\n\n\
+"Default": Use default reset type for the target.\n\
+"Hardware": Reset using the nRESET hardware signal.\n\
+"Software (Default)": Use default software reset type for the target.\n\
+"Software (SYSRESETREQ)": Use Cortex-M AIRCR.SYSRESETREQ register.\n\
+"Software (VECTRESET)":  Use Cortex-M AICR.VECTRESET register. Only \
+available on v7-M cores.\n\
+"Software (emulated)": Setting core registers to reset values.
 
 DebuggerTab.gdbServerResetType.Default=Default
 DebuggerTab.gdbServerResetType.Hardware=Hardware
 DebuggerTab.gdbServerResetType.SoftwareDefault=Software (Default)
 DebuggerTab.gdbServerResetType.SoftwareSysResetReq=Software (SYSRESETREQ)
 DebuggerTab.gdbServerResetType.SoftwareVectReset=Software (VECTRESET)
-DebuggerTab.gdbServerResetType.SoftwareEmulated=Software (emulated)
+DebuggerTab.gdbServerResetType.SoftwareEmulated=Software (Emulated)
 
 DebuggerTab.gdbServerHaltAtHardFault_Label=Halt at hard fault
 DebuggerTab.gdbServerHaltAtHardFault_ToolTipText=\
@@ -140,7 +160,8 @@ Step into interrupts
 
 DebuggerTab.gdbServerFlashMode_Label=Flash mode:
 DebuggerTab.gdbServerFlashMode_ToolTipText=\
-Mode of operation for writing to flash.
+Mode of operation for writing to flash. \
+"Auto" uses either chip or sector erase based on which should be fastest.
 
 DebuggerTab.gdbServerFlashMode.AutoErase=Auto
 DebuggerTab.gdbServerFlashMode.ChipErase=Chip erase
@@ -161,8 +182,10 @@ them directly in pyOCD.
 
 DebuggerTab.gdbServerOther_Label=Other options:
 DebuggerTab.gdbServerOther_ToolTipText=\
-Optional field, listing additional command-line \
-configuration options.
+Optional field, listing additional command line \
+arguments passed to pyocd. The additional arguments \
+are appended to the end of the command line. Arguments \
+can be space separated and/or placed on separate lines.
 
 DebuggerTab.gdbServerAllocateConsole_Label=Allocate console for pyOCD
 DebuggerTab.gdbServerAllocateConsole_ToolTipText=\

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/pyocd/ui/messages.properties
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/pyocd/ui/messages.properties
@@ -112,8 +112,10 @@ DebuggerTab.gdbServerFlashMode.AutoErase=Auto
 DebuggerTab.gdbServerFlashMode.ChipErase=Chip erase
 DebuggerTab.gdbServerFlashMode.SectorErase=Sector erase
 
-DebuggerTab.gdbServerFlashFastVerify_Label=Fast sector compare with CRC 
-DebuggerTab.gdbServerFlashFastVerify_ToolTipText=
+DebuggerTab.gdbServerSmartFlash_Label=Smart flash 
+DebuggerTab.gdbServerSmartFlash_ToolTipText=\
+Attempt to improve flash programming performance by only \
+programming those flash pages that have changed.
 
 DebuggerTab.gdbServerEnableSemihosting_Label=Enable semihosting
 DebuggerTab.gdbServerEnableSemihosting_ToolTipText=

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/pyocd/ui/messages.properties
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/pyocd/ui/messages.properties
@@ -96,6 +96,26 @@ target. This is required when using standalone debug probes \
 or on-board probes types such as J-Link that do not indicate \
 the connected target type.
 
+DebuggerTab.gdbServerConnectMode_Label=Connect mode:
+DebuggerTab.gdbServerConnectMode_ToolTipText=\
+Select how pyocd connects to the target.
+
+DebuggerTab.gdbServerConnectMode.Halt=Halt
+DebuggerTab.gdbServerConnectMode.PreReset=Pre-reset
+DebuggerTab.gdbServerConnectMode.UnderReset=Under reset
+DebuggerTab.gdbServerConnectMode.Attach=Attach
+
+DebuggerTab.gdbServerResetType_Label=Reset type:
+DebuggerTab.gdbServerResetType_ToolTipText=\
+Method used to reset the target.
+
+DebuggerTab.gdbServerResetType.Default=Default
+DebuggerTab.gdbServerResetType.Hardware=Hardware
+DebuggerTab.gdbServerResetType.SoftwareDefault=Software (Default)
+DebuggerTab.gdbServerResetType.SoftwareSysResetReq=Software (SYSRESETREQ)
+DebuggerTab.gdbServerResetType.SoftwareVectReset=Software (VECTRESET)
+DebuggerTab.gdbServerResetType.SoftwareEmulated=Software (emulated)
+
 DebuggerTab.gdbServerHaltAtHardFault_Label=Halt at hard fault
 DebuggerTab.gdbServerHaltAtHardFault_ToolTipText=\
 Halt at hard fault

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/pyocd/ui/messages.properties
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/pyocd/ui/messages.properties
@@ -91,10 +91,24 @@ DebuggerTab.gdbServerBusSpeedUnits_Label=Hz
 
 DebuggerTab.gdbServerOverrideTarget_Label=Override target:
 DebuggerTab.gdbServerOverrideTarget_ToolTipText=\
-Select a target device type from the menu to override the \
-target. This is required when using standalone debug probes \
-or on-board probes types such as J-Link that do not indicate \
-the connected target type.
+When enabled, the target device type is set to the item selected \
+with the combo box. If not enabled, the default target type \
+shown above is used. Setting the target type is required when using \
+standalone debug probes or on-board probes types such as J-Link \
+that do not report the connected target type.
+
+DebuggerTab.gdbServerTargetName_ToolTipText=\
+Select a device part number from the pull-down menu to manually specify the \
+target type. A custom value may also be entered in the field; this must \
+be the short target type name like those shown in parentheses in \
+the pull-down menu. Setting the target type is required when using \
+standalone debug probes or on-board probes types such as J-Link \
+that do not report the connected target type.
+
+DebuggerTab.gdbServerDefaultTargetType_Label=Default target:
+DebuggerTab.gdbServerDefaultTargetType_ToolTipText=\
+This is the target that will be used if the "Override target" \
+setting is not enabled. 
 
 DebuggerTab.gdbServerConnectMode_Label=Connect mode:
 DebuggerTab.gdbServerConnectMode_ToolTipText=\


### PR DESCRIPTION
This PR updates the pyocd launch config to support modern features of pyocd.

- Connect mode: pre-reset, under reset, halt (the default), attach.
- Reset type: target default, hw, various sw.
- Replace flash CRC check (fast verify) setting with smart flash option.
- Display the default target type for the selected probe/board.
- List targets in the default target type field and target type combo box as "vendor > {family >}* part-number (target)".

Some settings from the startup tab that don't make sense for pyocd are removed:

- First reset enable and type.
- Redundant semihosting enable.

Plus some improvements:

- pyocd's project directory is set to the Eclipse project location.
- Improved tool tip text.
- Fixed possible race between setting probe/target list fields and updating the corresponding UI elements.
- Some code cleanup.

Note: this PR includes the change in #470. I was planning to rebase this PR after the other is merged, but if you prefer we can close #470 and just use this one.