### PR TITLE
Fix NPE in CProjectAttributes.getCmsisDeviceVariantName()

### DIFF
--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.core/src/org/eclipse/embedcdt/debug/gdbjtag/core/data/CProjectAttributes.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.core/src/org/eclipse/embedcdt/debug/gdbjtag/core/data/CProjectAttributes.java
@@ -65,7 +65,7 @@ public class CProjectAttributes {
 	public static String getCmsisDeviceVariantName(ILaunchConfiguration configuration) {
 
 		String variantName = getCmsisAttribute(configuration, CProjectPacksStorage.CMSIS_DEVICE_VARIANT_NAME);
-		if (!variantName.isEmpty()) {
+		if (variantName != null && !variantName.isEmpty()) {
 			return variantName;
 		}
 


### PR DESCRIPTION
The NPE happened when I created a new J-Link launch config for a project which does not have a CMSIS device selected.