### PR TITLE
Add ability to customize GDB port when auto-starting gdb server

### DIFF
--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.openocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/openocd/core/ConfigurationAttributes.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.openocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/openocd/core/ConfigurationAttributes.java
@@ -52,6 +52,8 @@ public interface ConfigurationAttributes extends org.eclipse.embedcdt.debug.gdbj
 
 	public static final String GDB_CLIENT_OTHER_COMMANDS = PREFIX + ".gdbClientOtherCommands"; //$NON-NLS-1$
 
+	public static final String GDB_CONNECT_TO_GDB_SERVER = PREFIX + ".useHostNameAndPortOfStartedGdbServer"; //$NON-NLS-1$
+
 	// ------------------------------------------------------------------------
 
 	// TabStartup

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.openocd.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/openocd/ui/messages.properties
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.openocd.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/openocd/ui/messages.properties
@@ -134,6 +134,8 @@ are: 'set debug remote 1', 'set\n\
 remotetimeout 20'.
 
 DebuggerTab.remoteGroup_Text=Remote Target
+DebuggerTab.useHostNameAndPortOfStartedGdbServer=Use the host name, IP address and port number of the started GDB server
+DebuggerTab.useHostNameAndPortOfStartedGdbServer_ToolTipText=Under most conditions you will want to connect GDB to the localhost and port number specified above. However if your GDB server opens connections to multiple cores, you can specify which target to connect to here.
 DebuggerTab.ipAddressLabel=Host name or IP address:
 DebuggerTab.portNumberLabel=Port number:
 


### PR DESCRIPTION
When starting a gdbserver (like openocd) connected to a multi-core SoC the gdb server may open multiple ports. This change allows user to configure which port GDB connect to rather than forcing GDB to connec to the first port.

TODO list:

- [ ] Get approval for this idea in #569
- [x] Save the new checkbox state properly
- [ ] Review wording of the checkbox and tooltip (at the moment it is a bit wordy and maybe not clear enough)
- [ ] Apply this same change to all the other TabDebugger.java files

Fixes #569