### PR TITLE
Add ability to customize GDB port when auto-starting gdb server

### DIFF
--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.jlink.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/jlink/ui/messages.properties
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.jlink.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/jlink/ui/messages.properties
@@ -202,7 +202,9 @@ the target. Other useful commands are:\n\
 
 DebuggerTab.remoteGroup_Text=Remote Target
 DebuggerTab.ipAddressLabel=Host name or IP address:
+DebuggerTab.ipAddressWarningDecoration=The supplied value for the Host name or IP address does not match the address the J-Link GDB server is listening on. Click the warning to restore the default.
 DebuggerTab.portNumberLabel=Port number:
+DebuggerTab.portNumberWarningDecoration=The supplied port number does not match the port the J-Link GDB server is listening on. Click the warning to restore the default.
 
 
 DebuggerTab.update_thread_list_on_suspend_Text=Force thread list update on suspend

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.openocd.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/openocd/ui/messages.properties
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.openocd.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/openocd/ui/messages.properties
@@ -135,7 +135,9 @@ remotetimeout 20'.
 
 DebuggerTab.remoteGroup_Text=Remote Target
 DebuggerTab.ipAddressLabel=Host name or IP address:
+DebuggerTab.ipAddressWarningDecoration=The supplied value for the Host name or IP address does not match the address OpenOCD is listening on. Click the warning to restore the default.
 DebuggerTab.portNumberLabel=Port number:
+DebuggerTab.portNumberWarningDecoration=The supplied port number does not match the port OpenOCD is listening on. Click the warning to restore the default.
 
 
 DebuggerTab.update_thread_list_on_suspend_Text=Force thread list update on suspend

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabDebugger.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/debug/gdbjtag/pyocd/ui/TabDebugger.java
@@ -64,6 +64,8 @@ import org.eclipse.embedcdt.internal.debug.gdbjtag.pyocd.ui.preferences.GlobalMc
 import org.eclipse.embedcdt.internal.debug.gdbjtag.pyocd.ui.preferences.WorkspaceMcuPage;
 import org.eclipse.embedcdt.internal.debug.gdbjtag.pyocd.ui.properties.ProjectMcuPage;
 import org.eclipse.embedcdt.ui.SystemUIJob;
+import org.eclipse.jface.fieldassist.ControlDecoration;
+import org.eclipse.jface.fieldassist.FieldDecorationRegistry;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
@@ -119,6 +121,8 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 
 	private Text fTargetIpAddress;
 	private Text fTargetPortNumber;
+	private ControlDecoration fTargetPortNumberDecoration;
+	private ControlDecoration fTargetIpAddressDecoration;
 
 	private Combo fGdbServerProbeId;
 	private Button fGdbServerRefreshProbes;
@@ -658,6 +662,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 				doStartGdbServerChanged();
 				if (fDoStartGdbServer.getSelection()) {
 					fTargetIpAddress.setText(DefaultPreferences.REMOTE_IP_ADDRESS_LOCALHOST);
+					fTargetPortNumber.setText(fGdbServerGdbPort.getText());
 				}
 				scheduleUpdateJob();
 			}
@@ -931,6 +936,10 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 			GridData gd = new GridData();
 			gd.widthHint = 125;
 			fTargetIpAddress.setLayoutData(gd);
+			fTargetIpAddressDecoration = new ControlDecoration(fTargetIpAddress, SWT.LEFT | SWT.TOP);
+			fTargetIpAddressDecoration.setDescriptionText(Messages.getString("DebuggerTab.ipAddressWarningDecoration")); //$NON-NLS-1$
+			fTargetIpAddressDecoration.setImage(FieldDecorationRegistry.getDefault()
+					.getFieldDecoration(FieldDecorationRegistry.DEC_WARNING).getImage());
 
 			label = new Label(comp, SWT.NONE);
 			label.setText(Messages.getString("DebuggerTab.portNumberLabel")); //$NON-NLS-1$
@@ -939,6 +948,11 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 			gd = new GridData();
 			gd.widthHint = 125;
 			fTargetPortNumber.setLayoutData(gd);
+			fTargetPortNumberDecoration = new ControlDecoration(fTargetPortNumber, SWT.LEFT | SWT.TOP);
+			fTargetPortNumberDecoration
+					.setDescriptionText(Messages.getString("DebuggerTab.portNumberWarningDecoration")); //$NON-NLS-1$
+			fTargetPortNumberDecoration.setImage(FieldDecorationRegistry.getDefault()
+					.getFieldDecoration(FieldDecorationRegistry.DEC_WARNING).getImage());
 		}
 
 		// ---- Actions -------------------------------------------------------
@@ -947,6 +961,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 		fTargetIpAddress.addModifyListener(new ModifyListener() {
 			@Override
 			public void modifyText(ModifyEvent e) {
+				updateDecorations();
 				scheduleUpdateJob(); // provides much better performance for
 										// Text listeners
 			}
@@ -960,10 +975,24 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 		fTargetPortNumber.addModifyListener(new ModifyListener() {
 			@Override
 			public void modifyText(ModifyEvent e) {
+				updateDecorations();
 				scheduleUpdateJob(); // provides much better performance for
 										// Text listeners
 			}
 		});
+		fTargetIpAddressDecoration.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				fTargetIpAddress.setText(DefaultPreferences.REMOTE_IP_ADDRESS_DEFAULT);
+			}
+		});
+		fTargetPortNumberDecoration.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				fTargetPortNumber.setText(fGdbServerGdbPort.getText());
+			}
+		});
+
 	}
 
 	private void updateGdbServerActualPath() {
@@ -1025,12 +1054,10 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 		fDoGdbServerAllocateConsole.setEnabled(enabled);
 		fDoGdbServerAllocateSemihostingConsole.setEnabled(enabled);
 
-		// Disable remote target params when the server is started
-		fTargetIpAddress.setEnabled(!enabled);
-		fTargetPortNumber.setEnabled(!enabled);
-
 		fGdbServerPathLabel.setEnabled(enabled);
 		fLink.setEnabled(enabled);
+
+		updateDecorations();
 	}
 
 	private void overrideTargetChanged() {
@@ -1480,6 +1507,24 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 		}
 	}
 
+	protected void updateDecorations() {
+		if (fDoStartGdbServer.getSelection()) {
+			if (DefaultPreferences.REMOTE_IP_ADDRESS_DEFAULT.equals(fTargetIpAddress.getText())) {
+				fTargetIpAddressDecoration.hide();
+			} else {
+				fTargetIpAddressDecoration.show();
+			}
+			if (fGdbServerGdbPort.getText().equals(fTargetPortNumber.getText())) {
+				fTargetPortNumberDecoration.hide();
+			} else {
+				fTargetPortNumberDecoration.show();
+			}
+		} else {
+			fTargetIpAddressDecoration.hide();
+			fTargetPortNumberDecoration.hide();
+		}
+	}
+
 	@Override
 	public void initializeFrom(ILaunchConfiguration configuration) {
 		if (Activator.getInstance().isDebugging()) {
@@ -1729,8 +1774,12 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 		{
 			fTargetIpAddress.setText(DefaultPreferences.REMOTE_IP_ADDRESS_DEFAULT); // $NON-NLS-1$
 
-			String portString = Integer.toString(DefaultPreferences.REMOTE_PORT_NUMBER_DEFAULT); // $NON-NLS-1$
-			fTargetPortNumber.setText(portString);
+			if (fDoStartGdbServer.getSelection()) {
+				fTargetPortNumber.setText(fGdbServerGdbPort.getText());
+			} else {
+				String portString = Integer.toString(DefaultPreferences.REMOTE_PORT_NUMBER_DEFAULT); // $NON-NLS-1$
+				fTargetPortNumber.setText(portString);
+			}
 		}
 
 		doStartGdbServerChanged();
@@ -1978,31 +2027,15 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 		}
 
 		{
-			if (fDoStartGdbServer.getSelection()) {
-				configuration.setAttribute(IGDBJtagConstants.ATTR_IP_ADDRESS, "localhost");
-
-				String str = fGdbServerGdbPort.getText().trim();
-				if (!str.isEmpty()) {
-					try {
-						int port;
-						port = Integer.parseInt(str);
-						configuration.setAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER, port);
-					} catch (NumberFormatException e) {
-						Activator.log(e);
-					}
-				}
-			} else {
-				String ip = fTargetIpAddress.getText().trim();
-				configuration.setAttribute(IGDBJtagConstants.ATTR_IP_ADDRESS, ip);
-
-				String str = fTargetPortNumber.getText().trim();
-				if (!str.isEmpty()) {
-					try {
-						int port = Integer.valueOf(str).intValue();
-						configuration.setAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER, port);
-					} catch (NumberFormatException e) {
-						Activator.log(e);
-					}
+			String ip = fTargetIpAddress.getText().trim();
+			configuration.setAttribute(IGDBJtagConstants.ATTR_IP_ADDRESS, ip);
+			String str = fTargetPortNumber.getText().trim();
+			if (!str.isEmpty()) {
+				try {
+					int port = Integer.valueOf(str).intValue();
+					configuration.setAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER, port);
+				} catch (NumberFormatException e) {
+					Activator.log(e);
 				}
 			}
 		}

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/pyocd/ui/messages.properties
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/pyocd/ui/messages.properties
@@ -229,7 +229,9 @@ remotetimeout 20'.
 
 DebuggerTab.remoteGroup_Text=Remote Target
 DebuggerTab.ipAddressLabel=Host name or IP address:
+DebuggerTab.ipAddressWarningDecoration=The supplied value for the Host name or IP address does not match the address pyOCD is listening on. Click the warning to restore the default.
 DebuggerTab.portNumberLabel=Port number:
+DebuggerTab.portNumberWarningDecoration=The supplied port number does not match the port pyOCD is listening on. Click the warning to restore the default.
 
 
 DebuggerTab.update_thread_list_on_suspend_Text=Force thread list update on suspend

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.qemu.ui/src/org/eclipse/embedcdt/debug/gdbjtag/qemu/ui/TabDebugger.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.qemu.ui/src/org/eclipse/embedcdt/debug/gdbjtag/qemu/ui/TabDebugger.java
@@ -48,6 +48,8 @@ import org.eclipse.embedcdt.internal.debug.gdbjtag.qemu.ui.Messages;
 import org.eclipse.embedcdt.internal.debug.gdbjtag.qemu.ui.preferences.GlobalMcuPage;
 import org.eclipse.embedcdt.internal.debug.gdbjtag.qemu.ui.preferences.WorkspaceMcuPage;
 import org.eclipse.embedcdt.internal.debug.gdbjtag.qemu.ui.properties.ProjectMcuPage;
+import org.eclipse.jface.fieldassist.ControlDecoration;
+import org.eclipse.jface.fieldassist.FieldDecorationRegistry;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
@@ -98,6 +100,8 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 
 	private Text fTargetIpAddress;
 	private Text fTargetPortNumber;
+	private ControlDecoration fTargetPortNumberDecoration;
+	private ControlDecoration fTargetIpAddressDecoration;
 
 	private Text fQemuBoardName;
 	private Text fQemuDeviceName;
@@ -531,6 +535,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 				doStartGdbServerChanged();
 				if (fDoStartGdbServer.getSelection()) {
 					fTargetIpAddress.setText(DefaultPreferences.REMOTE_IP_ADDRESS_LOCALHOST);
+					fTargetPortNumber.setText(fGdbServerGdbPort.getText());
 				}
 				scheduleUpdateJob();
 			}
@@ -798,6 +803,10 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 			GridData gd = new GridData();
 			gd.widthHint = 125;
 			fTargetIpAddress.setLayoutData(gd);
+			fTargetIpAddressDecoration = new ControlDecoration(fTargetIpAddress, SWT.LEFT | SWT.TOP);
+			fTargetIpAddressDecoration.setDescriptionText(Messages.getString("DebuggerTab.ipAddressWarningDecoration")); //$NON-NLS-1$
+			fTargetIpAddressDecoration.setImage(FieldDecorationRegistry.getDefault()
+					.getFieldDecoration(FieldDecorationRegistry.DEC_WARNING).getImage());
 
 			label = new Label(comp, SWT.NONE);
 			label.setText(Messages.getString("DebuggerTab.portNumberLabel")); //$NON-NLS-1$
@@ -806,6 +815,12 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 			gd = new GridData();
 			gd.widthHint = 125;
 			fTargetPortNumber.setLayoutData(gd);
+			fTargetPortNumberDecoration = new ControlDecoration(fTargetPortNumber, SWT.LEFT | SWT.TOP);
+			fTargetPortNumberDecoration
+					.setDescriptionText(Messages.getString("DebuggerTab.portNumberWarningDecoration")); //$NON-NLS-1$
+			fTargetPortNumberDecoration.setImage(FieldDecorationRegistry.getDefault()
+					.getFieldDecoration(FieldDecorationRegistry.DEC_WARNING).getImage());
+
 		}
 
 		// ---- Actions -------------------------------------------------------
@@ -814,6 +829,7 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 		fTargetIpAddress.addModifyListener(new ModifyListener() {
 			@Override
 			public void modifyText(ModifyEvent e) {
+				updateDecorations();
 				scheduleUpdateJob(); // provides much better performance for
 										// Text listeners
 			}
@@ -827,11 +843,23 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 		fTargetPortNumber.addModifyListener(new ModifyListener() {
 			@Override
 			public void modifyText(ModifyEvent e) {
+				updateDecorations();
 				scheduleUpdateJob(); // provides much better performance for
 										// Text listeners
 			}
 		});
-
+		fTargetIpAddressDecoration.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				fTargetIpAddress.setText(DefaultPreferences.REMOTE_IP_ADDRESS_DEFAULT);
+			}
+		});
+		fTargetPortNumberDecoration.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				fTargetPortNumber.setText(fGdbServerGdbPort.getText());
+			}
+		});
 	}
 
 	private void updateGdbServerActualPath() {
@@ -879,14 +907,12 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 			fIsQemuVerbose.setEnabled(enabled);
 		}
 
-		// Disable remote target params when the server is started
-		fTargetIpAddress.setEnabled(!enabled);
-		fTargetPortNumber.setEnabled(!enabled);
-
 		fGdbServerPathLabel.setEnabled(enabled);
 		fLink.setEnabled(enabled);
 
 		fGdbServerDelay.setEnabled(enabled);
+
+		updateDecorations();
 	}
 
 	private void doEnableSemihostingChanged() {
@@ -919,6 +945,24 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 		}
 
 		return fProjectName;
+	}
+
+	protected void updateDecorations() {
+		if (fDoStartGdbServer.getSelection()) {
+			if (DefaultPreferences.REMOTE_IP_ADDRESS_DEFAULT.equals(fTargetIpAddress.getText())) {
+				fTargetIpAddressDecoration.hide();
+			} else {
+				fTargetIpAddressDecoration.show();
+			}
+			if (fGdbServerGdbPort.getText().equals(fTargetPortNumber.getText())) {
+				fTargetPortNumberDecoration.hide();
+			} else {
+				fTargetPortNumberDecoration.show();
+			}
+		} else {
+			fTargetIpAddressDecoration.hide();
+			fTargetPortNumberDecoration.hide();
+		}
 	}
 
 	@Override
@@ -1158,8 +1202,12 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 		{
 			fTargetIpAddress.setText(DefaultPreferences.REMOTE_IP_ADDRESS_DEFAULT); // $NON-NLS-1$
 
-			String portString = Integer.toString(DefaultPreferences.REMOTE_PORT_NUMBER_DEFAULT); // $NON-NLS-1$
-			fTargetPortNumber.setText(portString);
+			if (fDoStartGdbServer.getSelection()) {
+				fTargetPortNumber.setText(fGdbServerGdbPort.getText());
+			} else {
+				String portString = Integer.toString(DefaultPreferences.REMOTE_PORT_NUMBER_DEFAULT); // $NON-NLS-1$
+				fTargetPortNumber.setText(portString);
+			}
 		}
 	}
 
@@ -1369,31 +1417,16 @@ public class TabDebugger extends AbstractLaunchConfigurationTab {
 		}
 
 		{
-			if (fDoStartGdbServer.getSelection()) {
-				configuration.setAttribute(IGDBJtagConstants.ATTR_IP_ADDRESS, "localhost");
+			String ip = fTargetIpAddress.getText().trim();
+			configuration.setAttribute(IGDBJtagConstants.ATTR_IP_ADDRESS, ip);
 
-				String str = fGdbServerGdbPort.getText().trim();
-				if (!str.isEmpty()) {
-					try {
-						int port;
-						port = Integer.parseInt(str);
-						configuration.setAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER, port);
-					} catch (NumberFormatException e) {
-						Activator.log(e);
-					}
-				}
-			} else {
-				String ip = fTargetIpAddress.getText().trim();
-				configuration.setAttribute(IGDBJtagConstants.ATTR_IP_ADDRESS, ip);
-
-				String str = fTargetPortNumber.getText().trim();
-				if (!str.isEmpty()) {
-					try {
-						int port = Integer.valueOf(str).intValue();
-						configuration.setAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER, port);
-					} catch (NumberFormatException e) {
-						Activator.log(e);
-					}
+			String str = fTargetPortNumber.getText().trim();
+			if (!str.isEmpty()) {
+				try {
+					int port = Integer.valueOf(str).intValue();
+					configuration.setAttribute(IGDBJtagConstants.ATTR_PORT_NUMBER, port);
+				} catch (NumberFormatException e) {
+					Activator.log(e);
 				}
 			}
 		}

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.qemu.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/qemu/ui/messages.properties
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.qemu.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/qemu/ui/messages.properties
@@ -161,7 +161,9 @@ remotetimeout 20'.
 
 DebuggerTab.remoteGroup_Text=Remote Target
 DebuggerTab.ipAddressLabel=Host name or IP address:
+DebuggerTab.ipAddressWarningDecoration=The supplied value for the Host name or IP address does not match the address QEMU is listening on. Click the warning to restore the default.
 DebuggerTab.portNumberLabel=Port number:
+DebuggerTab.portNumberWarningDecoration=The supplied port number does not match the port QEMU is listening on. Click the warning to restore the default.
 
 
 DebuggerTab.update_thread_list_on_suspend_Text=Force thread list update on suspend


### PR DESCRIPTION
When starting a gdbserver (like openocd) connected to a multi-core SoC the gdb server may open multiple ports. This change allows user to configure which port GDB connect to rather than forcing GDB to connect to the first port.

When the ports do not match a warning triangle is displayed which can be clicked on to restore the matching values.

When a user changes the "GDB port" in the "Start TYPE locally" section that is reflected in the "Port number" in the "Remote Target" section.

Changes to "Port number" in the "Remote Target" which lead to the ports not matching will display the warning triangle.

TODO:

- [x] Get approval for this solution in #569
- [ ] Review wording of tool-tips on label decorations
- [x] Apply this same change to all the other TabDebugger.java files

Fixes #569