### PR TITLE
Add some visual separation between toolchain settings

### DIFF
--- a/plugins/org.eclipse.embedcdt.managedbuild.cross.arm.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/arm/ui/Messages.java
+++ b/plugins/org.eclipse.embedcdt.managedbuild.cross.arm.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/arm/ui/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2013 Marc-Andre Laperle and others.
+ * Copyright (c) 2011, 2023 Marc-Andre Laperle and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -64,9 +64,25 @@ public class Messages extends NLS {
 	public static String ToolchainPaths_label;
 	public static String ToolchainName_label;
 
+	public static String ProjectToolchainsPathPropertiesPage_GlobalSettings_link;
+
+	public static String ProjectToolchainsPathPropertiesPage_ToolchainMessageAllConfigs_label;
+
+	public static String ProjectToolchainsPathPropertiesPage_ToolchainMessageSomeConfigs_label;
+
+	public static String ProjectToolchainsPathPropertiesPage_WorkspaceSettings_link;
+
 	public static String ProjectToolchainsPathsPropertiesPage_description;
 	public static String WorkspaceToolchainsPathsPreferencesPage_description;
 	public static String GlobalToolchainsPathsPreferencesPage_description;
+
+	public static String GlobalToolchainsPathsPreferencesPage_ToolchainDefaultGroup_label;
+
+	public static String GlobalToolchainsPathsPreferencesPage_ToolchainMessageDefault_label;
+
+	public static String GlobalToolchainsPathsPreferencesPage_ToolchainMessageWithProjects_label;
+
+	public static String GlobalToolchainsPathsPreferencesPage_ToolchainPathGroup_label;
 
 	public static String SetCrossCommandWizardPage_text;
 

--- a/plugins/org.eclipse.embedcdt.managedbuild.cross.arm.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/arm/ui/messages.properties
+++ b/plugins/org.eclipse.embedcdt.managedbuild.cross.arm.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/arm/ui/messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2013 Marc-Andre Laperle
+# Copyright (c) 2011, 2023 Marc-Andre Laperle and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -64,29 +64,41 @@ ToolsPaths_ToolchainName_label=Toolchain name:
 ToolchainPaths_label=Toolchain folder:
 ToolchainName_label=Default toolchain:
 
+ProjectToolchainsPathPropertiesPage_GlobalSettings_link=<a>Configure Global Settings...</a>
+ProjectToolchainsPathPropertiesPage_ToolchainMessageAllConfigs_label=Toolchain used in this project by all configurations
+ProjectToolchainsPathPropertiesPage_ToolchainMessageSomeConfigs_label=Toolchain used in this project by the following configurations: {0}
+ProjectToolchainsPathPropertiesPage_WorkspaceSettings_link=<a>Configure Workspace Settings...</a>\n
 ProjectToolchainsPathsPropertiesPage_description=\
 Configure the location where various GNU Arm toolchains are installed. \
-The values are stored in the workspace (not in the project). \
-They are used for all build configurations of this project, \
-and override the workspace or global paths. \
+A path specified on this page is stored in the project and override the workspace or global paths.\n\
+As the toolchain locations specified here are stored in the project, it is generally not a good idea to \
+specify paths here. Instead prefer to specify toolchain locations either at the Workspace or Global \
+preferences.\n\
+Only the toolchains in use by this project are shown on this page.\
 \n
 
 WorkspaceToolchainsPathsPreferencesPage_description=\
 Configure the locations where various GNU Arm toolchains are installed. \
-The paths are stored in the workspace and override the global paths. \
+A path specified on this page is stored in the workspace and override the global paths. \
 Unless redefined per project, they are used for all \
-projects in this workspace. \
+projects in this workspace.\n\
+Only the toolchains in use by projects in the workspace are shown on this page. \
 \n
 
 GlobalToolchainsPathsPreferencesPage_description=\
 Configure the locations where various GNU Arm toolchains are installed. \
 The values are stored within Eclipse. \
 Unless redefined more specifically, they are used for all \
-projects in all workspaces. \
+projects in all workspaces.\n\
+Only the toolchains in use by projects in the workspace are shown on this page. \
 \n
+GlobalToolchainsPathsPreferencesPage_ToolchainDefaultGroup_label=Select the default toolchain to be used when creating new projects
+GlobalToolchainsPathsPreferencesPage_ToolchainMessageDefault_label=Toolchain used by default for new projects
+GlobalToolchainsPathsPreferencesPage_ToolchainMessageWithProjects_label=Toolchain used by the following projects: {0}
+GlobalToolchainsPathsPreferencesPage_ToolchainPathGroup_label=Specify toolchain paths for in use toolchains
 
 SetCrossCommandWizardPage_text=\
 On macOS use Shift+Cmd+'.' to show the hidden folders while browsing the file system. \
-xpm uses a .content folder to store the binaries.\n
+xpm uses a .content folder to store the binaries.
 
 

--- a/plugins/org.eclipse.embedcdt.managedbuild.cross.arm.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/arm/ui/preferences/GlobalToolchainsPathsPreferencesPage.java
+++ b/plugins/org.eclipse.embedcdt.managedbuild.cross.arm.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/arm/ui/preferences/GlobalToolchainsPathsPreferencesPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Liviu Ionescu.
+ * Copyright (c) 2015, 2023 Liviu Ionescu and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,8 +15,12 @@
 
 package org.eclipse.embedcdt.internal.managedbuild.cross.arm.ui.preferences;
 
-import java.util.HashSet;
+import java.util.Comparator;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.eclipse.cdt.managedbuilder.core.BuildException;
 import org.eclipse.cdt.managedbuilder.core.IConfiguration;
@@ -35,10 +39,15 @@ import org.eclipse.embedcdt.managedbuild.cross.arm.ui.preferences.ToolchainsFiel
 import org.eclipse.embedcdt.managedbuild.cross.core.preferences.PersistentPreferences;
 import org.eclipse.embedcdt.ui.LabelFakeFieldEditor;
 import org.eclipse.embedcdt.ui.XpackDirectoryNotStrictFieldEditor;
+import org.eclipse.jface.layout.PixelConverter;
 import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
@@ -97,21 +106,22 @@ public class GlobalToolchainsPathsPreferencesPage extends FieldEditorPreferenceP
 	 */
 	@Override
 	protected void createFieldEditors() {
+		final Composite parent = getFieldEditorParent();
+		final GridLayout layout = new GridLayout();
+		layout.marginWidth = 0;
+		parent.setLayout(layout);
 
-		boolean isStrict;
-
-		FieldEditor toolchainNameField = new ToolchainsFieldEditor(PersistentPreferences.TOOLCHAIN_ID_KEY,
-				Messages.ToolchainName_label, getFieldEditorParent());
-		addField(toolchainNameField);
-
-		Set<ToolchainDefinition> toolchains = new HashSet<>();
+		Map<ToolchainDefinition, Map<String, Set<String>>> toolchains = new TreeMap<>(
+				Comparator.comparing(ToolchainDefinition::getName));
 
 		IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
-		for (int i = 0; i < projects.length; ++i) {
-			IConfiguration[] configs = EclipseUtils.getConfigurationsForProject(projects[i]);
+		for (IProject project : projects) {
+			IConfiguration[] configs = EclipseUtils.getConfigurationsForProject(project);
+			boolean allConfigsUseSameToolchain = true;
+			ToolchainDefinition toolchainInUse = null;
 			if (configs != null) {
-				for (int j = 0; j < configs.length; ++j) {
-					IToolChain toolchain = configs[j].getToolChain();
+				for (IConfiguration config : configs) {
+					IToolChain toolchain = config.getToolChain();
 					if (toolchain == null) {
 						continue;
 					}
@@ -120,7 +130,16 @@ public class GlobalToolchainsPathsPreferencesPage extends FieldEditorPreferenceP
 						try {
 							String toolchainId = optionId.getStringValue();
 							int ix = ToolchainDefinition.findToolchainById(toolchainId);
-							toolchains.add(ToolchainDefinition.getToolchain(ix));
+
+							ToolchainDefinition toolchainDefinition = ToolchainDefinition.getToolchain(ix);
+							if (toolchainInUse == null) {
+								toolchainInUse = toolchainDefinition;
+							} else if (!toolchainInUse.equals(toolchainDefinition)) {
+								allConfigsUseSameToolchain = false;
+							}
+							var projectMap = toolchains.computeIfAbsent(toolchainDefinition, x -> new TreeMap<>());
+							var buildConfigsSet = projectMap.computeIfAbsent(project.getName(), x -> new TreeSet<>());
+							buildConfigsSet.add(config.getName());
 							continue;
 						} catch (BuildException e) {
 						} catch (IndexOutOfBoundsException e) {
@@ -131,12 +150,28 @@ public class GlobalToolchainsPathsPreferencesPage extends FieldEditorPreferenceP
 						try {
 							String toolchainName = optionName.getStringValue();
 							int ix = ToolchainDefinition.findToolchainByName(toolchainName);
-							toolchains.add(ToolchainDefinition.getToolchain(ix));
+
+							ToolchainDefinition toolchainDefinition = ToolchainDefinition.getToolchain(ix);
+							if (toolchainInUse == null) {
+								toolchainInUse = toolchainDefinition;
+							} else if (!toolchainInUse.equals(toolchainDefinition)) {
+								allConfigsUseSameToolchain = false;
+							}
+							var projectMap = toolchains.computeIfAbsent(toolchainDefinition, x -> new TreeMap<>());
+							var buildConfigsSet = projectMap.computeIfAbsent(project.getName(), x -> new TreeSet<>());
+							buildConfigsSet.add(config.getName());
 						} catch (BuildException e) {
 						} catch (IndexOutOfBoundsException e) {
 						}
 					}
 				}
+			}
+
+			if (allConfigsUseSameToolchain && toolchainInUse != null) {
+				Set<String> set = toolchains.get(toolchainInUse).get(project.getName());
+				// If all the configurations use the same toolchain, don't display
+				// any of the configurations in the UI
+				set.clear();
 			}
 		}
 
@@ -144,7 +179,7 @@ public class GlobalToolchainsPathsPreferencesPage extends FieldEditorPreferenceP
 			try {
 				String toolchainId = fPersistentPreferences.getToolchainId();
 				int ix = ToolchainDefinition.findToolchainById(toolchainId);
-				toolchains.add(ToolchainDefinition.getToolchain(ix));
+				toolchains.computeIfAbsent(ToolchainDefinition.getToolchain(ix), x -> Map.of());
 			} catch (IndexOutOfBoundsException e) {
 			}
 		}
@@ -153,37 +188,111 @@ public class GlobalToolchainsPathsPreferencesPage extends FieldEditorPreferenceP
 			try {
 				String toolchainName = fPersistentPreferences.getToolchainName();
 				int ix = ToolchainDefinition.findToolchainByName(toolchainName);
-				toolchains.add(ToolchainDefinition.getToolchain(ix));
+				toolchains.computeIfAbsent(ToolchainDefinition.getToolchain(ix), x -> Map.of());
 			} catch (IndexOutOfBoundsException e) {
 			}
 		}
 
 		if (toolchains.isEmpty()) {
 			int ix = ToolchainDefinition.getDefault();
-			toolchains.add(ToolchainDefinition.getToolchain(ix));
+			toolchains.computeIfAbsent(ToolchainDefinition.getToolchain(ix), x -> Map.of());
 		}
 
-		for (ToolchainDefinition toolchain : toolchains) {
+		final Group group = new Group(parent, SWT.NONE);
+		group.setText(Messages.GlobalToolchainsPathsPreferencesPage_ToolchainPathGroup_label);
+		GridLayout groupLayout = new GridLayout(4, false);
+		group.setLayout(groupLayout);
+		group.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+		boolean first = true;
+		for (var entry : toolchains.entrySet()) {
+			if (first) {
+				first = false;
+			} else {
+				Label verticalSpacer = new Label(group, SWT.NONE);
+				GridData layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
+				verticalSpacer.setLayoutData(layoutData);
+				verticalSpacer.setText("");
+			}
+
+			ToolchainDefinition toolchain = entry.getKey();
+			var projectToConfigsMap = entry.getValue();
+
+			Label message = new Label(group, SWT.WRAP);
+			GridData layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
+			message.setLayoutData(layoutData);
+			if (projectToConfigsMap.isEmpty()) {
+				message.setText(Messages.GlobalToolchainsPathsPreferencesPage_ToolchainMessageDefault_label);
+			} else {
+				String collected = projectToConfigsMap.entrySet().stream().map(e -> {
+					String projectName = e.getKey();
+					Set<String> configNames = e.getValue();
+					if (configNames.isEmpty()) {
+						return projectName;
+					} else {
+						return projectName + " (" + String.join(", ", configNames) + ")";
+					}
+				}).collect(Collectors.joining(", "));
+				message.setText(NLS.bind(
+						Messages.GlobalToolchainsPathsPreferencesPage_ToolchainMessageWithProjects_label, collected));
+
+			}
+			PixelConverter pixelConverter = new PixelConverter(message);
+			layoutData.widthHint = pixelConverter
+					.convertWidthInCharsToPixels(Math.min(message.getText().length(), 100));
 
 			FieldEditor labelField = new LabelFakeFieldEditor(toolchain.getFullName(),
-					Messages.ToolsPaths_ToolchainName_label, getFieldEditorParent());
+					Messages.ToolsPaths_ToolchainName_label, group);
+			labelField.fillIntoGrid(group, 4);
 			addField(labelField);
 
-			isStrict = fDefaultPreferences.getBoolean(PersistentPreferences.WORKSPACE_TOOLCHAIN_PATH_STRICT, true);
+			boolean isStrict = fDefaultPreferences.getBoolean(PersistentPreferences.WORKSPACE_TOOLCHAIN_PATH_STRICT,
+					true);
 
 			String[] xpackNames = fDefaultPreferences.getToolchainXpackNames(toolchain.getId(), toolchain.getName());
 
 			String key = PersistentPreferences.getToolchainKey(toolchain.getId(), toolchain.getName());
 			FieldEditor toolchainPathField = new XpackDirectoryNotStrictFieldEditor(xpackNames, key,
-					Messages.ToolchainPaths_label, getFieldEditorParent(), isStrict);
-
+					Messages.ToolchainPaths_label, group, isStrict);
+			toolchainPathField.fillIntoGrid(group, 4);
 			addField(toolchainPathField);
 		}
 
-		Label message = new Label(getFieldEditorParent(), SWT.NONE);
+		Label verticalSpacer = new Label(group, SWT.NONE);
 		GridData layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
-		message.setLayoutData(layoutData);
-		message.setText(Messages.SetCrossCommandWizardPage_text);
+		verticalSpacer.setLayoutData(layoutData);
+		verticalSpacer.setText("");
+
+		Label macOSMessage = new Label(group, SWT.NONE);
+		layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
+		macOSMessage.setLayoutData(layoutData);
+		macOSMessage.setText(Messages.SetCrossCommandWizardPage_text);
+
+		// Layout need to be reset after fields are added
+		group.setLayout(groupLayout);
+
+		final Group group1 = new Group(parent, SWT.NONE);
+		group1.setText(Messages.GlobalToolchainsPathsPreferencesPage_ToolchainDefaultGroup_label);
+		GridLayout group1Layout = new GridLayout(2, false);
+		group1.setLayout(group1Layout);
+		group1.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+		FieldEditor toolchainNameField = new ToolchainsFieldEditor(PersistentPreferences.TOOLCHAIN_ID_KEY,
+				Messages.ToolchainName_label, group1);
+		toolchainNameField.fillIntoGrid(group1, 2);
+		// ComboFieldEditor does not grab excess space (like StringFieldEditor does) therefore
+		// we need to specify that here. ComboFieldEditor also doesn't provide an equivalent
+		// to StringFieldEditor.getTextControl, hence the need to get control's layout data
+		// like this
+		((GridData) group1.getChildren()[1].getLayoutData()).grabExcessHorizontalSpace = true;
+		addField(toolchainNameField);
+		// Layout need to be reset after fields are added
+		group1.setLayout(group1Layout);
+	}
+
+	@Override
+	protected void adjustGridLayout() {
+		// do nothing as we are manually handling the grid layout in createFieldEditors
 	}
 
 	// ------------------------------------------------------------------------

--- a/plugins/org.eclipse.embedcdt.managedbuild.cross.arm.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/arm/ui/preferences/WorkspaceToolchainsPathsPreferencesPage.java
+++ b/plugins/org.eclipse.embedcdt.managedbuild.cross.arm.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/arm/ui/preferences/WorkspaceToolchainsPathsPreferencesPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Liviu Ionescu.
+ * Copyright (c) 2015, 2023 Liviu Ionescu and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,8 +15,12 @@
 
 package org.eclipse.embedcdt.internal.managedbuild.cross.arm.ui.preferences;
 
-import java.util.HashSet;
+import java.util.Comparator;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.eclipse.cdt.managedbuilder.core.BuildException;
 import org.eclipse.cdt.managedbuilder.core.IConfiguration;
@@ -36,10 +40,15 @@ import org.eclipse.embedcdt.managedbuild.cross.core.preferences.PersistentPrefer
 import org.eclipse.embedcdt.ui.LabelFakeFieldEditor;
 import org.eclipse.embedcdt.ui.XpackDirectoryNotStrictFieldEditor;
 import org.eclipse.embedcdt.ui.preferences.ScopedPreferenceStoreWithoutDefaults;
+import org.eclipse.jface.layout.PixelConverter;
 import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
@@ -97,21 +106,22 @@ public class WorkspaceToolchainsPathsPreferencesPage extends FieldEditorPreferen
 	 */
 	@Override
 	protected void createFieldEditors() {
+		final Composite parent = getFieldEditorParent();
+		final GridLayout layout = new GridLayout();
+		layout.marginWidth = 0;
+		parent.setLayout(layout);
 
-		boolean isStrict;
-
-		FieldEditor toolchainNameField = new ToolchainsFieldEditor(PersistentPreferences.TOOLCHAIN_ID_KEY,
-				Messages.ToolchainName_label, getFieldEditorParent());
-		addField(toolchainNameField);
-
-		Set<ToolchainDefinition> toolchains = new HashSet<>();
+		Map<ToolchainDefinition, Map<String, Set<String>>> toolchains = new TreeMap<>(
+				Comparator.comparing(ToolchainDefinition::getName));
 
 		IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
-		for (int i = 0; i < projects.length; ++i) {
-			IConfiguration[] configs = EclipseUtils.getConfigurationsForProject(projects[i]);
+		for (IProject project : projects) {
+			IConfiguration[] configs = EclipseUtils.getConfigurationsForProject(project);
+			boolean allConfigsUseSameToolchain = true;
+			ToolchainDefinition toolchainInUse = null;
 			if (configs != null) {
-				for (int j = 0; j < configs.length; ++j) {
-					IToolChain toolchain = configs[j].getToolChain();
+				for (IConfiguration config : configs) {
+					IToolChain toolchain = config.getToolChain();
 					if (toolchain == null) {
 						continue;
 					}
@@ -120,7 +130,16 @@ public class WorkspaceToolchainsPathsPreferencesPage extends FieldEditorPreferen
 						try {
 							String toolchainId = optionId.getStringValue();
 							int ix = ToolchainDefinition.findToolchainById(toolchainId);
-							toolchains.add(ToolchainDefinition.getToolchain(ix));
+
+							ToolchainDefinition toolchainDefinition = ToolchainDefinition.getToolchain(ix);
+							if (toolchainInUse == null) {
+								toolchainInUse = toolchainDefinition;
+							} else if (!toolchainInUse.equals(toolchainDefinition)) {
+								allConfigsUseSameToolchain = false;
+							}
+							var projectMap = toolchains.computeIfAbsent(toolchainDefinition, x -> new TreeMap<>());
+							var buildConfigsSet = projectMap.computeIfAbsent(project.getName(), x -> new TreeSet<>());
+							buildConfigsSet.add(config.getName());
 							continue;
 						} catch (BuildException e) {
 						} catch (IndexOutOfBoundsException e) {
@@ -131,13 +150,28 @@ public class WorkspaceToolchainsPathsPreferencesPage extends FieldEditorPreferen
 						try {
 							String toolchainName = optionName.getStringValue();
 							int ix = ToolchainDefinition.findToolchainByName(toolchainName);
-							toolchains.add(ToolchainDefinition.getToolchain(ix));
-							continue;
+
+							ToolchainDefinition toolchainDefinition = ToolchainDefinition.getToolchain(ix);
+							if (toolchainInUse == null) {
+								toolchainInUse = toolchainDefinition;
+							} else if (!toolchainInUse.equals(toolchainDefinition)) {
+								allConfigsUseSameToolchain = false;
+							}
+							var projectMap = toolchains.computeIfAbsent(toolchainDefinition, x -> new TreeMap<>());
+							var buildConfigsSet = projectMap.computeIfAbsent(project.getName(), x -> new TreeSet<>());
+							buildConfigsSet.add(config.getName());
 						} catch (BuildException e) {
 						} catch (IndexOutOfBoundsException e) {
 						}
 					}
 				}
+			}
+
+			if (allConfigsUseSameToolchain && toolchainInUse != null) {
+				Set<String> set = toolchains.get(toolchainInUse).get(project.getName());
+				// If all the configurations use the same toolchain, don't display
+				// any of the configurations in the UI
+				set.clear();
 			}
 		}
 
@@ -145,7 +179,7 @@ public class WorkspaceToolchainsPathsPreferencesPage extends FieldEditorPreferen
 			try {
 				String toolchainId = fPersistentPreferences.getToolchainId();
 				int ix = ToolchainDefinition.findToolchainById(toolchainId);
-				toolchains.add(ToolchainDefinition.getToolchain(ix));
+				toolchains.computeIfAbsent(ToolchainDefinition.getToolchain(ix), x -> Map.of());
 			} catch (IndexOutOfBoundsException e) {
 			}
 		}
@@ -154,37 +188,111 @@ public class WorkspaceToolchainsPathsPreferencesPage extends FieldEditorPreferen
 			try {
 				String toolchainName = fPersistentPreferences.getToolchainName();
 				int ix = ToolchainDefinition.findToolchainByName(toolchainName);
-				toolchains.add(ToolchainDefinition.getToolchain(ix));
+				toolchains.computeIfAbsent(ToolchainDefinition.getToolchain(ix), x -> Map.of());
 			} catch (IndexOutOfBoundsException e) {
 			}
 		}
 
 		if (toolchains.isEmpty()) {
 			int ix = ToolchainDefinition.getDefault();
-			toolchains.add(ToolchainDefinition.getToolchain(ix));
+			toolchains.computeIfAbsent(ToolchainDefinition.getToolchain(ix), x -> Map.of());
 		}
 
-		for (ToolchainDefinition toolchain : toolchains) {
+		final Group group = new Group(parent, SWT.NONE);
+		group.setText(Messages.GlobalToolchainsPathsPreferencesPage_ToolchainPathGroup_label);
+		GridLayout groupLayout = new GridLayout(4, false);
+		group.setLayout(groupLayout);
+		group.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+		boolean first = true;
+		for (var entry : toolchains.entrySet()) {
+			if (first) {
+				first = false;
+			} else {
+				Label verticalSpacer = new Label(group, SWT.NONE);
+				GridData layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
+				verticalSpacer.setLayoutData(layoutData);
+				verticalSpacer.setText("");
+			}
+
+			ToolchainDefinition toolchain = entry.getKey();
+			var projectToConfigsMap = entry.getValue();
+
+			Label message = new Label(group, SWT.WRAP);
+			GridData layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
+			message.setLayoutData(layoutData);
+			if (projectToConfigsMap.isEmpty()) {
+				message.setText(Messages.GlobalToolchainsPathsPreferencesPage_ToolchainMessageDefault_label);
+			} else {
+				String collected = projectToConfigsMap.entrySet().stream().map(e -> {
+					String projectName = e.getKey();
+					Set<String> configNames = e.getValue();
+					if (configNames.isEmpty()) {
+						return projectName;
+					} else {
+						return projectName + " (" + String.join(", ", configNames) + ")";
+					}
+				}).collect(Collectors.joining(", "));
+				message.setText(NLS.bind(
+						Messages.GlobalToolchainsPathsPreferencesPage_ToolchainMessageWithProjects_label, collected));
+
+			}
+			PixelConverter pixelConverter = new PixelConverter(message);
+			layoutData.widthHint = pixelConverter
+					.convertWidthInCharsToPixels(Math.min(message.getText().length(), 100));
 
 			FieldEditor labelField = new LabelFakeFieldEditor(toolchain.getFullName(),
-					Messages.ToolsPaths_ToolchainName_label, getFieldEditorParent());
+					Messages.ToolsPaths_ToolchainName_label, group);
+			labelField.fillIntoGrid(group, 4);
 			addField(labelField);
 
-			isStrict = fDefaultPreferences.getBoolean(PersistentPreferences.WORKSPACE_TOOLCHAIN_PATH_STRICT, true);
+			boolean isStrict = fDefaultPreferences.getBoolean(PersistentPreferences.WORKSPACE_TOOLCHAIN_PATH_STRICT,
+					true);
 
 			String[] xpackNames = fDefaultPreferences.getToolchainXpackNames(toolchain.getId(), toolchain.getName());
 
 			String key = PersistentPreferences.getToolchainKey(toolchain.getId(), toolchain.getName());
 			FieldEditor toolchainPathField = new XpackDirectoryNotStrictFieldEditor(xpackNames, key,
-					Messages.ToolchainPaths_label, getFieldEditorParent(), isStrict);
-
+					Messages.ToolchainPaths_label, group, isStrict);
+			toolchainPathField.fillIntoGrid(group, 4);
 			addField(toolchainPathField);
 		}
 
-		Label message = new Label(getFieldEditorParent(), SWT.NONE);
+		Label verticalSpacer = new Label(group, SWT.NONE);
 		GridData layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
-		message.setLayoutData(layoutData);
-		message.setText(Messages.SetCrossCommandWizardPage_text);
+		verticalSpacer.setLayoutData(layoutData);
+		verticalSpacer.setText("");
+
+		Label macOSMessage = new Label(group, SWT.NONE);
+		layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
+		macOSMessage.setLayoutData(layoutData);
+		macOSMessage.setText(Messages.SetCrossCommandWizardPage_text);
+
+		// Layout need to be reset after fields are added
+		group.setLayout(groupLayout);
+
+		final Group group1 = new Group(parent, SWT.NONE);
+		group1.setText(Messages.GlobalToolchainsPathsPreferencesPage_ToolchainDefaultGroup_label);
+		GridLayout group1Layout = new GridLayout(2, false);
+		group1.setLayout(group1Layout);
+		group1.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+		FieldEditor toolchainNameField = new ToolchainsFieldEditor(PersistentPreferences.TOOLCHAIN_ID_KEY,
+				Messages.ToolchainName_label, group1);
+		toolchainNameField.fillIntoGrid(group1, 2);
+		// ComboFieldEditor does not grab excess space (like StringFieldEditor does) therefore
+		// we need to specify that here. ComboFieldEditor also doesn't provide an equivalent
+		// to StringFieldEditor.getTextControl, hence the need to get control's layout data
+		// like this
+		((GridData) group1.getChildren()[1].getLayoutData()).grabExcessHorizontalSpace = true;
+		addField(toolchainNameField);
+		// Layout need to be reset after fields are added
+		group1.setLayout(group1Layout);
+	}
+
+	@Override
+	protected void adjustGridLayout() {
+		// do nothing as we are manually handling the grid layout in createFieldEditors
 	}
 
 	// ------------------------------------------------------------------------

--- a/plugins/org.eclipse.embedcdt.managedbuild.cross.arm.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/arm/ui/properties/ProjectToolchainsPathPropertiesPage.java
+++ b/plugins/org.eclipse.embedcdt.managedbuild.cross.arm.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/arm/ui/properties/ProjectToolchainsPathPropertiesPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Liviu Ionescu.
+ * Copyright (c) 2015, 2023 Liviu Ionescu and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,8 +15,11 @@
 
 package org.eclipse.embedcdt.internal.managedbuild.cross.arm.ui.properties;
 
-import java.util.HashSet;
+import java.util.Comparator;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 import org.eclipse.cdt.managedbuilder.core.BuildException;
 import org.eclipse.cdt.managedbuilder.core.IConfiguration;
@@ -27,6 +30,8 @@ import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.embedcdt.core.EclipseUtils;
 import org.eclipse.embedcdt.internal.managedbuild.cross.arm.ui.Activator;
 import org.eclipse.embedcdt.internal.managedbuild.cross.arm.ui.Messages;
+import org.eclipse.embedcdt.internal.managedbuild.cross.arm.ui.preferences.GlobalToolchainsPathsPreferencesPage;
+import org.eclipse.embedcdt.internal.managedbuild.cross.arm.ui.preferences.WorkspaceToolchainsPathsPreferencesPage;
 import org.eclipse.embedcdt.managedbuild.cross.arm.core.Option;
 import org.eclipse.embedcdt.managedbuild.cross.arm.core.ToolchainDefinition;
 import org.eclipse.embedcdt.managedbuild.cross.core.preferences.DefaultPreferences;
@@ -35,11 +40,19 @@ import org.eclipse.embedcdt.ui.FieldEditorPropertyPage;
 import org.eclipse.embedcdt.ui.LabelFakeFieldEditor;
 import org.eclipse.embedcdt.ui.XpackDirectoryNotStrictFieldEditor;
 import org.eclipse.embedcdt.ui.preferences.ScopedPreferenceStoreWithoutDefaults;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.PixelConverter;
 import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
+import org.eclipse.ui.dialogs.PreferencesUtil;
 
 public class ProjectToolchainsPathPropertiesPage extends FieldEditorPropertyPage {
 
@@ -76,21 +89,49 @@ public class ProjectToolchainsPathPropertiesPage extends FieldEditorPropertyPage
 		return null;
 	}
 
+	/**
+	 * Creates the field editors. Field editors are abstractions of the common GUI
+	 * blocks needed to manipulate various types of preferences. Each field editor
+	 * knows how to save and restore itself.
+	 */
 	@Override
 	protected void createFieldEditors() {
+		final Composite parent = getFieldEditorParent();
+		final GridLayout layout = new GridLayout();
+		layout.marginWidth = 0;
+		parent.setLayout(layout);
 
-		boolean isStrict;
+		Link link = new Link(parent, SWT.NONE);
+		link.setText(Messages.ProjectToolchainsPathPropertiesPage_GlobalSettings_link);
+		link.setLayoutData(GridDataFactory.fillDefaults().create());
+		link.addListener(SWT.Selection, e -> {
+			PreferencesUtil
+					.createPreferenceDialogOn(parent.getShell(), GlobalToolchainsPathsPreferencesPage.ID, new String[] {
+							WorkspaceToolchainsPathsPreferencesPage.ID, GlobalToolchainsPathsPreferencesPage.ID }, null)
+					.open();
+		});
+		link = new Link(parent, SWT.NONE);
+		link.setText(Messages.ProjectToolchainsPathPropertiesPage_WorkspaceSettings_link);
+		link.setLayoutData(GridDataFactory.fillDefaults().create());
+		link.addListener(SWT.Selection, e -> {
+			PreferencesUtil.createPreferenceDialogOn(parent.getShell(), WorkspaceToolchainsPathsPreferencesPage.ID,
+					new String[] { WorkspaceToolchainsPathsPreferencesPage.ID,
+							GlobalToolchainsPathsPreferencesPage.ID },
+					null).open();
+		});
 
-		Set<ToolchainDefinition> toolchains = new HashSet<>();
+		Map<ToolchainDefinition, Set<String>> toolchains = new TreeMap<>(
+				Comparator.comparing(ToolchainDefinition::getName));
 
 		Object element = getElement();
 		if (element instanceof IProject) {
-			// TODO: get project toolchain name. How?
 			IProject project = (IProject) element;
 			IConfiguration[] configs = EclipseUtils.getConfigurationsForProject(project);
+			boolean allConfigsUseSameToolchain = true;
+			ToolchainDefinition toolchainInUse = null;
 			if (configs != null) {
-				for (int i = 0; i < configs.length; ++i) {
-					IToolChain toolchain = configs[i].getToolChain();
+				for (IConfiguration config : configs) {
+					IToolChain toolchain = config.getToolChain();
 					if (toolchain == null) {
 						continue;
 					}
@@ -99,7 +140,15 @@ public class ProjectToolchainsPathPropertiesPage extends FieldEditorPropertyPage
 						try {
 							String toolchainId = optionId.getStringValue();
 							int ix = ToolchainDefinition.findToolchainById(toolchainId);
-							toolchains.add(ToolchainDefinition.getToolchain(ix));
+
+							ToolchainDefinition toolchainDefinition = ToolchainDefinition.getToolchain(ix);
+							if (toolchainInUse == null) {
+								toolchainInUse = toolchainDefinition;
+							} else if (!toolchainInUse.equals(toolchainDefinition)) {
+								allConfigsUseSameToolchain = false;
+							}
+							var buildConfigsSet = toolchains.computeIfAbsent(toolchainDefinition, x -> new TreeSet<>());
+							buildConfigsSet.add(config.getName());
 							continue;
 						} catch (BuildException e) {
 						} catch (IndexOutOfBoundsException e) {
@@ -110,13 +159,27 @@ public class ProjectToolchainsPathPropertiesPage extends FieldEditorPropertyPage
 						try {
 							String toolchainName = optionName.getStringValue();
 							int ix = ToolchainDefinition.findToolchainByName(toolchainName);
-							toolchains.add(ToolchainDefinition.getToolchain(ix));
-							continue;
+
+							ToolchainDefinition toolchainDefinition = ToolchainDefinition.getToolchain(ix);
+							if (toolchainInUse == null) {
+								toolchainInUse = toolchainDefinition;
+							} else if (!toolchainInUse.equals(toolchainDefinition)) {
+								allConfigsUseSameToolchain = false;
+							}
+							var buildConfigsSet = toolchains.computeIfAbsent(toolchainDefinition, x -> new TreeSet<>());
+							buildConfigsSet.add(config.getName());
 						} catch (BuildException e) {
 						} catch (IndexOutOfBoundsException e) {
 						}
 					}
 				}
+			}
+
+			if (allConfigsUseSameToolchain && toolchainInUse != null) {
+				Set<String> set = toolchains.get(toolchainInUse);
+				// If all the configurations use the same toolchain, don't display
+				// any of the configurations in the UI
+				set.clear();
 			}
 		}
 
@@ -124,7 +187,7 @@ public class ProjectToolchainsPathPropertiesPage extends FieldEditorPropertyPage
 			try {
 				String toolchainId = fPersistentPreferences.getToolchainId();
 				int ix = ToolchainDefinition.findToolchainById(toolchainId);
-				toolchains.add(ToolchainDefinition.getToolchain(ix));
+				toolchains.computeIfAbsent(ToolchainDefinition.getToolchain(ix), x -> Set.of());
 			} catch (IndexOutOfBoundsException e) {
 			}
 		}
@@ -133,37 +196,84 @@ public class ProjectToolchainsPathPropertiesPage extends FieldEditorPropertyPage
 			try {
 				String toolchainName = fPersistentPreferences.getToolchainName();
 				int ix = ToolchainDefinition.findToolchainByName(toolchainName);
-				toolchains.add(ToolchainDefinition.getToolchain(ix));
+				toolchains.computeIfAbsent(ToolchainDefinition.getToolchain(ix), x -> Set.of());
 			} catch (IndexOutOfBoundsException e) {
 			}
 		}
 
 		if (toolchains.isEmpty()) {
 			int ix = ToolchainDefinition.getDefault();
-			toolchains.add(ToolchainDefinition.getToolchain(ix));
+			toolchains.computeIfAbsent(ToolchainDefinition.getToolchain(ix), x -> Set.of());
 		}
 
-		for (ToolchainDefinition toolchain : toolchains) {
+		final Group group = new Group(parent, SWT.NONE);
+		group.setText(Messages.GlobalToolchainsPathsPreferencesPage_ToolchainPathGroup_label);
+		GridLayout groupLayout = new GridLayout(4, false);
+		group.setLayout(groupLayout);
+		group.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+		boolean first = true;
+		for (var entry : toolchains.entrySet()) {
+			if (first) {
+				first = false;
+			} else {
+				Label verticalSpacer = new Label(group, SWT.NONE);
+				GridData layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
+				verticalSpacer.setLayoutData(layoutData);
+				verticalSpacer.setText("");
+			}
+
+			ToolchainDefinition toolchain = entry.getKey();
+			var configSet = entry.getValue();
+
+			Label message = new Label(group, SWT.WRAP);
+			GridData layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
+			message.setLayoutData(layoutData);
+			if (configSet.isEmpty()) {
+				message.setText(Messages.ProjectToolchainsPathPropertiesPage_ToolchainMessageAllConfigs_label);
+			} else {
+				String collected = String.join(", ", configSet);
+				message.setText(NLS.bind(Messages.ProjectToolchainsPathPropertiesPage_ToolchainMessageSomeConfigs_label,
+						collected));
+			}
+			PixelConverter pixelConverter = new PixelConverter(message);
+			layoutData.widthHint = pixelConverter
+					.convertWidthInCharsToPixels(Math.min(message.getText().length(), 100));
 
 			FieldEditor labelField = new LabelFakeFieldEditor(toolchain.getFullName(),
-					Messages.ToolsPaths_ToolchainName_label, getFieldEditorParent());
+					Messages.ToolsPaths_ToolchainName_label, group);
+			labelField.fillIntoGrid(group, 4);
 			addField(labelField);
 
-			isStrict = fDefaultPreferences.getBoolean(PersistentPreferences.PROJECT_TOOLCHAIN_PATH_STRICT, true);
+			boolean isStrict = fDefaultPreferences.getBoolean(PersistentPreferences.PROJECT_TOOLCHAIN_PATH_STRICT,
+					true);
 
 			String[] xpackNames = fDefaultPreferences.getToolchainXpackNames(toolchain.getId(), toolchain.getName());
 
 			String key = PersistentPreferences.getToolchainKey(toolchain.getId(), toolchain.getName());
 			FieldEditor toolchainPathField = new XpackDirectoryNotStrictFieldEditor(xpackNames, key,
-					Messages.ToolchainPaths_label, getFieldEditorParent(), isStrict);
-
+					Messages.ToolchainPaths_label, group, isStrict);
+			toolchainPathField.fillIntoGrid(group, 4);
 			addField(toolchainPathField);
 		}
 
-		Label message = new Label(getFieldEditorParent(), SWT.NONE);
+		Label verticalSpacer = new Label(group, SWT.NONE);
 		GridData layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
-		message.setLayoutData(layoutData);
-		message.setText(Messages.SetCrossCommandWizardPage_text);
+		verticalSpacer.setLayoutData(layoutData);
+		verticalSpacer.setText("");
+
+		Label macOSMessage = new Label(group, SWT.NONE);
+		layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
+		macOSMessage.setLayoutData(layoutData);
+		macOSMessage.setText(Messages.SetCrossCommandWizardPage_text);
+
+		// Layout need to be reset after fields are added
+		group.setLayout(groupLayout);
+	}
+
+	@Override
+	protected void adjustGridLayout() {
+		// do nothing as we are manually handling the grid layout in createFieldEditors
 	}
 
 	// ------------------------------------------------------------------------

--- a/plugins/org.eclipse.embedcdt.managedbuild.cross.riscv.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/riscv/ui/Messages.java
+++ b/plugins/org.eclipse.embedcdt.managedbuild.cross.riscv.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/riscv/ui/Messages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2013 Marc-Andre Laperle and others.
+ * Copyright (c) 2011, 2023 Marc-Andre Laperle and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -64,10 +64,25 @@ public class Messages extends NLS {
 
 	public static String ToolchainPaths_label;
 	public static String ToolchainName_label;
+	public static String ProjectToolchainsPathPropertiesPage_GlobalSettings_link;
+
+	public static String ProjectToolchainsPathPropertiesPage_ToolchainMessageAllConfigs_label;
+
+	public static String ProjectToolchainsPathPropertiesPage_ToolchainMessageSomeConfigs_label;
+
+	public static String ProjectToolchainsPathPropertiesPage_WorkspaceSettings_link;
 
 	public static String ProjectToolchainsPathsPropertiesPage_description;
 	public static String WorkspaceToolchainsPathsPreferencesPage_description;
 	public static String GlobalToolchainsPathsPreferencesPage_description;
+
+	public static String GlobalToolchainsPathsPreferencesPage_ToolchainDefaultGroup_label;
+
+	public static String GlobalToolchainsPathsPreferencesPage_ToolchainMessageDefault_label;
+
+	public static String GlobalToolchainsPathsPreferencesPage_ToolchainMessageWithProjects_label;
+
+	public static String GlobalToolchainsPathsPreferencesPage_ToolchainPathGroup_label;
 
 	public static String SetCrossCommandWizardPage_text;
 

--- a/plugins/org.eclipse.embedcdt.managedbuild.cross.riscv.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/riscv/ui/messages.properties
+++ b/plugins/org.eclipse.embedcdt.managedbuild.cross.riscv.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/riscv/ui/messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2013 Marc-Andre Laperle
+# Copyright (c) 2011, 2023 Marc-Andre Laperle and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -63,28 +63,42 @@ ToolsPaths_ToolchainName_label=Toolchain name:
 ToolchainPaths_label=Toolchain folder:
 ToolchainName_label=Default toolchain:
 
+ProjectToolchainsPathPropertiesPage_GlobalSettings_link=<a>Configure Global Settings...</a>
+ProjectToolchainsPathPropertiesPage_ToolchainMessageAllConfigs_label=Toolchain used in this project by all configurations
+ProjectToolchainsPathPropertiesPage_ToolchainMessageSomeConfigs_label=Toolchain used in this project by the following configurations: {0}
+ProjectToolchainsPathPropertiesPage_WorkspaceSettings_link=<a>Configure Workspace Settings...</a>\n
+
 ProjectToolchainsPathsPropertiesPage_description=\
 Configure the location where various GNU RISC-V toolchains are installed. \
-The values are stored in the workspace (not in the project). \
-They are used for all build configurations of this project, \
-and override the workspace or global paths. \
+A path specified on this page is stored in the project and override the workspace or global paths.\n\
+As the toolchain locations specified here are stored in the project, it is generally not a good idea to \
+specify paths here. Instead prefer to specify toolchain locations either at the Workspace or Global \
+preferences.\n\
+Only the toolchains in use by this project are shown on this page.\
 \n
 
 WorkspaceToolchainsPathsPreferencesPage_description=\
 Configure the locations where various GNU RISC-V toolchains are installed. \
-The paths are stored in the workspace and override the global paths. \
+A path specified on this page is stored in the workspace and override the global paths. \
 Unless redefined per project, they are used for all \
-projects in this workspace. \
+projects in this workspace.\n\
+Only the toolchains in use by projects in the workspace are shown on this page. \
 \n
 
 GlobalToolchainsPathsPreferencesPage_description=\
 Configure the locations where various GNU RISC-V toolchains are installed. \
 The values are stored within Eclipse. \
 Unless redefined more specifically, they are used for all \
-projects in all workspaces. \
+projects in all workspaces.\n\
+Only the toolchains in use by projects in the workspace are shown on this page. \
 \n
+
+GlobalToolchainsPathsPreferencesPage_ToolchainDefaultGroup_label=Select the default toolchain to be used when creating new projects
+GlobalToolchainsPathsPreferencesPage_ToolchainMessageDefault_label=Toolchain used by default for new projects
+GlobalToolchainsPathsPreferencesPage_ToolchainMessageWithProjects_label=Toolchain used by the following projects: {0}
+GlobalToolchainsPathsPreferencesPage_ToolchainPathGroup_label=Specify toolchain paths for in use toolchains
 
 SetCrossCommandWizardPage_text=\
 On macOS use Shift+Cmd+'.' to show the hidden folders while browsing the file system. \
-xpm uses a .content folder to store the binaries.\n
+xpm uses a .content folder to store the binaries.
 

--- a/plugins/org.eclipse.embedcdt.managedbuild.cross.riscv.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/riscv/ui/preferences/GlobalToolchainsPathsPreferencesPage.java
+++ b/plugins/org.eclipse.embedcdt.managedbuild.cross.riscv.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/riscv/ui/preferences/GlobalToolchainsPathsPreferencesPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Liviu Ionescu.
+ * Copyright (c) 2015, 2023 Liviu Ionescu and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,8 +15,12 @@
 
 package org.eclipse.embedcdt.internal.managedbuild.cross.riscv.ui.preferences;
 
-import java.util.HashSet;
+import java.util.Comparator;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.eclipse.cdt.managedbuilder.core.BuildException;
 import org.eclipse.cdt.managedbuilder.core.IConfiguration;
@@ -35,10 +39,15 @@ import org.eclipse.embedcdt.managedbuild.cross.riscv.core.ToolchainDefinition;
 import org.eclipse.embedcdt.managedbuild.cross.riscv.ui.preferences.ToolchainsFieldEditor;
 import org.eclipse.embedcdt.ui.LabelFakeFieldEditor;
 import org.eclipse.embedcdt.ui.XpackDirectoryNotStrictFieldEditor;
+import org.eclipse.jface.layout.PixelConverter;
 import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
@@ -97,21 +106,22 @@ public class GlobalToolchainsPathsPreferencesPage extends FieldEditorPreferenceP
 	 */
 	@Override
 	protected void createFieldEditors() {
+		final Composite parent = getFieldEditorParent();
+		final GridLayout layout = new GridLayout();
+		layout.marginWidth = 0;
+		parent.setLayout(layout);
 
-		boolean isStrict;
-
-		FieldEditor toolchainNameField = new ToolchainsFieldEditor(PersistentPreferences.TOOLCHAIN_ID_KEY,
-				Messages.ToolchainName_label, getFieldEditorParent());
-		addField(toolchainNameField);
-
-		Set<ToolchainDefinition> toolchains = new HashSet<>();
+		Map<ToolchainDefinition, Map<String, Set<String>>> toolchains = new TreeMap<>(
+				Comparator.comparing(ToolchainDefinition::getName));
 
 		IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
-		for (int i = 0; i < projects.length; ++i) {
-			IConfiguration[] configs = EclipseUtils.getConfigurationsForProject(projects[i]);
+		for (IProject project : projects) {
+			IConfiguration[] configs = EclipseUtils.getConfigurationsForProject(project);
+			boolean allConfigsUseSameToolchain = true;
+			ToolchainDefinition toolchainInUse = null;
 			if (configs != null) {
-				for (int j = 0; j < configs.length; ++j) {
-					IToolChain toolchain = configs[j].getToolChain();
+				for (IConfiguration config : configs) {
+					IToolChain toolchain = config.getToolChain();
 					if (toolchain == null) {
 						continue;
 					}
@@ -120,7 +130,16 @@ public class GlobalToolchainsPathsPreferencesPage extends FieldEditorPreferenceP
 						try {
 							String toolchainId = optionId.getStringValue();
 							int ix = ToolchainDefinition.findToolchainById(toolchainId);
-							toolchains.add(ToolchainDefinition.getToolchain(ix));
+
+							ToolchainDefinition toolchainDefinition = ToolchainDefinition.getToolchain(ix);
+							if (toolchainInUse == null) {
+								toolchainInUse = toolchainDefinition;
+							} else if (!toolchainInUse.equals(toolchainDefinition)) {
+								allConfigsUseSameToolchain = false;
+							}
+							var projectMap = toolchains.computeIfAbsent(toolchainDefinition, x -> new TreeMap<>());
+							var buildConfigsSet = projectMap.computeIfAbsent(project.getName(), x -> new TreeSet<>());
+							buildConfigsSet.add(config.getName());
 							continue;
 						} catch (BuildException e) {
 						} catch (IndexOutOfBoundsException e) {
@@ -131,12 +150,28 @@ public class GlobalToolchainsPathsPreferencesPage extends FieldEditorPreferenceP
 						try {
 							String toolchainName = optionName.getStringValue();
 							int ix = ToolchainDefinition.findToolchainByName(toolchainName);
-							toolchains.add(ToolchainDefinition.getToolchain(ix));
+
+							ToolchainDefinition toolchainDefinition = ToolchainDefinition.getToolchain(ix);
+							if (toolchainInUse == null) {
+								toolchainInUse = toolchainDefinition;
+							} else if (!toolchainInUse.equals(toolchainDefinition)) {
+								allConfigsUseSameToolchain = false;
+							}
+							var projectMap = toolchains.computeIfAbsent(toolchainDefinition, x -> new TreeMap<>());
+							var buildConfigsSet = projectMap.computeIfAbsent(project.getName(), x -> new TreeSet<>());
+							buildConfigsSet.add(config.getName());
 						} catch (BuildException e) {
 						} catch (IndexOutOfBoundsException e) {
 						}
 					}
 				}
+			}
+
+			if (allConfigsUseSameToolchain && toolchainInUse != null) {
+				Set<String> set = toolchains.get(toolchainInUse).get(project.getName());
+				// If all the configurations use the same toolchain, don't display
+				// any of the configurations in the UI
+				set.clear();
 			}
 		}
 
@@ -144,7 +179,7 @@ public class GlobalToolchainsPathsPreferencesPage extends FieldEditorPreferenceP
 			try {
 				String toolchainId = fPersistentPreferences.getToolchainId();
 				int ix = ToolchainDefinition.findToolchainById(toolchainId);
-				toolchains.add(ToolchainDefinition.getToolchain(ix));
+				toolchains.computeIfAbsent(ToolchainDefinition.getToolchain(ix), x -> Map.of());
 			} catch (IndexOutOfBoundsException e) {
 			}
 		}
@@ -153,37 +188,111 @@ public class GlobalToolchainsPathsPreferencesPage extends FieldEditorPreferenceP
 			try {
 				String toolchainName = fPersistentPreferences.getToolchainName();
 				int ix = ToolchainDefinition.findToolchainByName(toolchainName);
-				toolchains.add(ToolchainDefinition.getToolchain(ix));
+				toolchains.computeIfAbsent(ToolchainDefinition.getToolchain(ix), x -> Map.of());
 			} catch (IndexOutOfBoundsException e) {
 			}
 		}
 
 		if (toolchains.isEmpty()) {
 			int ix = ToolchainDefinition.getDefault();
-			toolchains.add(ToolchainDefinition.getToolchain(ix));
+			toolchains.computeIfAbsent(ToolchainDefinition.getToolchain(ix), x -> Map.of());
 		}
 
-		for (ToolchainDefinition toolchain : toolchains) {
+		final Group group = new Group(parent, SWT.NONE);
+		group.setText(Messages.GlobalToolchainsPathsPreferencesPage_ToolchainPathGroup_label);
+		GridLayout groupLayout = new GridLayout(4, false);
+		group.setLayout(groupLayout);
+		group.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+		boolean first = true;
+		for (var entry : toolchains.entrySet()) {
+			if (first) {
+				first = false;
+			} else {
+				Label verticalSpacer = new Label(group, SWT.NONE);
+				GridData layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
+				verticalSpacer.setLayoutData(layoutData);
+				verticalSpacer.setText("");
+			}
+
+			ToolchainDefinition toolchain = entry.getKey();
+			var projectToConfigsMap = entry.getValue();
+
+			Label message = new Label(group, SWT.WRAP);
+			GridData layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
+			message.setLayoutData(layoutData);
+			if (projectToConfigsMap.isEmpty()) {
+				message.setText(Messages.GlobalToolchainsPathsPreferencesPage_ToolchainMessageDefault_label);
+			} else {
+				String collected = projectToConfigsMap.entrySet().stream().map(e -> {
+					String projectName = e.getKey();
+					Set<String> configNames = e.getValue();
+					if (configNames.isEmpty()) {
+						return projectName;
+					} else {
+						return projectName + " (" + String.join(", ", configNames) + ")";
+					}
+				}).collect(Collectors.joining(", "));
+				message.setText(NLS.bind(
+						Messages.GlobalToolchainsPathsPreferencesPage_ToolchainMessageWithProjects_label, collected));
+
+			}
+			PixelConverter pixelConverter = new PixelConverter(message);
+			layoutData.widthHint = pixelConverter
+					.convertWidthInCharsToPixels(Math.min(message.getText().length(), 100));
 
 			FieldEditor labelField = new LabelFakeFieldEditor(toolchain.getFullName(),
-					Messages.ToolsPaths_ToolchainName_label, getFieldEditorParent());
+					Messages.ToolsPaths_ToolchainName_label, group);
+			labelField.fillIntoGrid(group, 4);
 			addField(labelField);
 
-			isStrict = fDefaultPreferences.getBoolean(PersistentPreferences.WORKSPACE_TOOLCHAIN_PATH_STRICT, true);
+			boolean isStrict = fDefaultPreferences.getBoolean(PersistentPreferences.WORKSPACE_TOOLCHAIN_PATH_STRICT,
+					true);
 
 			String[] xpackNames = fDefaultPreferences.getToolchainXpackNames(toolchain.getId(), toolchain.getName());
 
 			String key = PersistentPreferences.getToolchainKey(toolchain.getId(), toolchain.getName());
 			FieldEditor toolchainPathField = new XpackDirectoryNotStrictFieldEditor(xpackNames, key,
-					Messages.ToolchainPaths_label, getFieldEditorParent(), isStrict);
-
+					Messages.ToolchainPaths_label, group, isStrict);
+			toolchainPathField.fillIntoGrid(group, 4);
 			addField(toolchainPathField);
 		}
 
-		Label message = new Label(getFieldEditorParent(), SWT.NONE);
+		Label verticalSpacer = new Label(group, SWT.NONE);
 		GridData layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
-		message.setLayoutData(layoutData);
-		message.setText(Messages.SetCrossCommandWizardPage_text);
+		verticalSpacer.setLayoutData(layoutData);
+		verticalSpacer.setText("");
+
+		Label macOSMessage = new Label(group, SWT.NONE);
+		layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
+		macOSMessage.setLayoutData(layoutData);
+		macOSMessage.setText(Messages.SetCrossCommandWizardPage_text);
+
+		// Layout need to be reset after fields are added
+		group.setLayout(groupLayout);
+
+		final Group group1 = new Group(parent, SWT.NONE);
+		group1.setText(Messages.GlobalToolchainsPathsPreferencesPage_ToolchainDefaultGroup_label);
+		GridLayout group1Layout = new GridLayout(2, false);
+		group1.setLayout(group1Layout);
+		group1.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+		FieldEditor toolchainNameField = new ToolchainsFieldEditor(PersistentPreferences.TOOLCHAIN_ID_KEY,
+				Messages.ToolchainName_label, group1);
+		toolchainNameField.fillIntoGrid(group1, 2);
+		// ComboFieldEditor does not grab excess space (like StringFieldEditor does) therefore
+		// we need to specify that here. ComboFieldEditor also doesn't provide an equivalent
+		// to StringFieldEditor.getTextControl, hence the need to get control's layout data
+		// like this
+		((GridData) group1.getChildren()[1].getLayoutData()).grabExcessHorizontalSpace = true;
+		addField(toolchainNameField);
+		// Layout need to be reset after fields are added
+		group1.setLayout(group1Layout);
+	}
+
+	@Override
+	protected void adjustGridLayout() {
+		// do nothing as we are manually handling the grid layout in createFieldEditors
 	}
 
 	// ------------------------------------------------------------------------

--- a/plugins/org.eclipse.embedcdt.managedbuild.cross.riscv.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/riscv/ui/preferences/WorkspaceToolchainsPathsPreferencesPage.java
+++ b/plugins/org.eclipse.embedcdt.managedbuild.cross.riscv.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/riscv/ui/preferences/WorkspaceToolchainsPathsPreferencesPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Liviu Ionescu.
+ * Copyright (c) 2015, 2023 Liviu Ionescu and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,8 +15,12 @@
 
 package org.eclipse.embedcdt.internal.managedbuild.cross.riscv.ui.preferences;
 
-import java.util.HashSet;
+import java.util.Comparator;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.eclipse.cdt.managedbuilder.core.BuildException;
 import org.eclipse.cdt.managedbuilder.core.IConfiguration;
@@ -36,10 +40,15 @@ import org.eclipse.embedcdt.managedbuild.cross.riscv.ui.preferences.ToolchainsFi
 import org.eclipse.embedcdt.ui.LabelFakeFieldEditor;
 import org.eclipse.embedcdt.ui.XpackDirectoryNotStrictFieldEditor;
 import org.eclipse.embedcdt.ui.preferences.ScopedPreferenceStoreWithoutDefaults;
+import org.eclipse.jface.layout.PixelConverter;
 import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
@@ -97,21 +106,22 @@ public class WorkspaceToolchainsPathsPreferencesPage extends FieldEditorPreferen
 	 */
 	@Override
 	protected void createFieldEditors() {
+		final Composite parent = getFieldEditorParent();
+		final GridLayout layout = new GridLayout();
+		layout.marginWidth = 0;
+		parent.setLayout(layout);
 
-		boolean isStrict;
-
-		FieldEditor toolchainNameField = new ToolchainsFieldEditor(PersistentPreferences.TOOLCHAIN_ID_KEY,
-				Messages.ToolchainName_label, getFieldEditorParent());
-		addField(toolchainNameField);
-
-		Set<ToolchainDefinition> toolchains = new HashSet<>();
+		Map<ToolchainDefinition, Map<String, Set<String>>> toolchains = new TreeMap<>(
+				Comparator.comparing(ToolchainDefinition::getName));
 
 		IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
-		for (int i = 0; i < projects.length; ++i) {
-			IConfiguration[] configs = EclipseUtils.getConfigurationsForProject(projects[i]);
+		for (IProject project : projects) {
+			IConfiguration[] configs = EclipseUtils.getConfigurationsForProject(project);
+			boolean allConfigsUseSameToolchain = true;
+			ToolchainDefinition toolchainInUse = null;
 			if (configs != null) {
-				for (int j = 0; j < configs.length; ++j) {
-					IToolChain toolchain = configs[j].getToolChain();
+				for (IConfiguration config : configs) {
+					IToolChain toolchain = config.getToolChain();
 					if (toolchain == null) {
 						continue;
 					}
@@ -120,7 +130,16 @@ public class WorkspaceToolchainsPathsPreferencesPage extends FieldEditorPreferen
 						try {
 							String toolchainId = optionId.getStringValue();
 							int ix = ToolchainDefinition.findToolchainById(toolchainId);
-							toolchains.add(ToolchainDefinition.getToolchain(ix));
+
+							ToolchainDefinition toolchainDefinition = ToolchainDefinition.getToolchain(ix);
+							if (toolchainInUse == null) {
+								toolchainInUse = toolchainDefinition;
+							} else if (!toolchainInUse.equals(toolchainDefinition)) {
+								allConfigsUseSameToolchain = false;
+							}
+							var projectMap = toolchains.computeIfAbsent(toolchainDefinition, x -> new TreeMap<>());
+							var buildConfigsSet = projectMap.computeIfAbsent(project.getName(), x -> new TreeSet<>());
+							buildConfigsSet.add(config.getName());
 							continue;
 						} catch (BuildException e) {
 						} catch (IndexOutOfBoundsException e) {
@@ -131,13 +150,28 @@ public class WorkspaceToolchainsPathsPreferencesPage extends FieldEditorPreferen
 						try {
 							String toolchainName = optionName.getStringValue();
 							int ix = ToolchainDefinition.findToolchainByName(toolchainName);
-							toolchains.add(ToolchainDefinition.getToolchain(ix));
-							continue;
+
+							ToolchainDefinition toolchainDefinition = ToolchainDefinition.getToolchain(ix);
+							if (toolchainInUse == null) {
+								toolchainInUse = toolchainDefinition;
+							} else if (!toolchainInUse.equals(toolchainDefinition)) {
+								allConfigsUseSameToolchain = false;
+							}
+							var projectMap = toolchains.computeIfAbsent(toolchainDefinition, x -> new TreeMap<>());
+							var buildConfigsSet = projectMap.computeIfAbsent(project.getName(), x -> new TreeSet<>());
+							buildConfigsSet.add(config.getName());
 						} catch (BuildException e) {
 						} catch (IndexOutOfBoundsException e) {
 						}
 					}
 				}
+			}
+
+			if (allConfigsUseSameToolchain && toolchainInUse != null) {
+				Set<String> set = toolchains.get(toolchainInUse).get(project.getName());
+				// If all the configurations use the same toolchain, don't display
+				// any of the configurations in the UI
+				set.clear();
 			}
 		}
 
@@ -145,7 +179,7 @@ public class WorkspaceToolchainsPathsPreferencesPage extends FieldEditorPreferen
 			try {
 				String toolchainId = fPersistentPreferences.getToolchainId();
 				int ix = ToolchainDefinition.findToolchainById(toolchainId);
-				toolchains.add(ToolchainDefinition.getToolchain(ix));
+				toolchains.computeIfAbsent(ToolchainDefinition.getToolchain(ix), x -> Map.of());
 			} catch (IndexOutOfBoundsException e) {
 			}
 		}
@@ -154,38 +188,111 @@ public class WorkspaceToolchainsPathsPreferencesPage extends FieldEditorPreferen
 			try {
 				String toolchainName = fPersistentPreferences.getToolchainName();
 				int ix = ToolchainDefinition.findToolchainByName(toolchainName);
-				toolchains.add(ToolchainDefinition.getToolchain(ix));
+				toolchains.computeIfAbsent(ToolchainDefinition.getToolchain(ix), x -> Map.of());
 			} catch (IndexOutOfBoundsException e) {
 			}
 		}
 
 		if (toolchains.isEmpty()) {
 			int ix = ToolchainDefinition.getDefault();
-			toolchains.add(ToolchainDefinition.getToolchain(ix));
+			toolchains.computeIfAbsent(ToolchainDefinition.getToolchain(ix), x -> Map.of());
 		}
 
-		for (ToolchainDefinition toolchain : toolchains) {
+		final Group group = new Group(parent, SWT.NONE);
+		group.setText(Messages.GlobalToolchainsPathsPreferencesPage_ToolchainPathGroup_label);
+		GridLayout groupLayout = new GridLayout(4, false);
+		group.setLayout(groupLayout);
+		group.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+		boolean first = true;
+		for (var entry : toolchains.entrySet()) {
+			if (first) {
+				first = false;
+			} else {
+				Label verticalSpacer = new Label(group, SWT.NONE);
+				GridData layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
+				verticalSpacer.setLayoutData(layoutData);
+				verticalSpacer.setText("");
+			}
+
+			ToolchainDefinition toolchain = entry.getKey();
+			var projectToConfigsMap = entry.getValue();
+
+			Label message = new Label(group, SWT.WRAP);
+			GridData layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
+			message.setLayoutData(layoutData);
+			if (projectToConfigsMap.isEmpty()) {
+				message.setText(Messages.GlobalToolchainsPathsPreferencesPage_ToolchainMessageDefault_label);
+			} else {
+				String collected = projectToConfigsMap.entrySet().stream().map(e -> {
+					String projectName = e.getKey();
+					Set<String> configNames = e.getValue();
+					if (configNames.isEmpty()) {
+						return projectName;
+					} else {
+						return projectName + " (" + String.join(", ", configNames) + ")";
+					}
+				}).collect(Collectors.joining(", "));
+				message.setText(NLS.bind(
+						Messages.GlobalToolchainsPathsPreferencesPage_ToolchainMessageWithProjects_label, collected));
+
+			}
+			PixelConverter pixelConverter = new PixelConverter(message);
+			layoutData.widthHint = pixelConverter
+					.convertWidthInCharsToPixels(Math.min(message.getText().length(), 100));
 
 			FieldEditor labelField = new LabelFakeFieldEditor(toolchain.getFullName(),
-					Messages.ToolsPaths_ToolchainName_label, getFieldEditorParent());
+					Messages.ToolsPaths_ToolchainName_label, group);
+			labelField.fillIntoGrid(group, 4);
 			addField(labelField);
 
-			isStrict = fDefaultPreferences.getBoolean(PersistentPreferences.WORKSPACE_TOOLCHAIN_PATH_STRICT, true);
+			boolean isStrict = fDefaultPreferences.getBoolean(PersistentPreferences.WORKSPACE_TOOLCHAIN_PATH_STRICT,
+					true);
 
 			String[] xpackNames = fDefaultPreferences.getToolchainXpackNames(toolchain.getId(), toolchain.getName());
 
 			String key = PersistentPreferences.getToolchainKey(toolchain.getId(), toolchain.getName());
 			FieldEditor toolchainPathField = new XpackDirectoryNotStrictFieldEditor(xpackNames, key,
-					Messages.ToolchainPaths_label, getFieldEditorParent(), isStrict);
-
+					Messages.ToolchainPaths_label, group, isStrict);
+			toolchainPathField.fillIntoGrid(group, 4);
 			addField(toolchainPathField);
 		}
 
-		Label message = new Label(getFieldEditorParent(), SWT.NONE);
+		Label verticalSpacer = new Label(group, SWT.NONE);
 		GridData layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
-		message.setLayoutData(layoutData);
-		message.setText(Messages.SetCrossCommandWizardPage_text);
+		verticalSpacer.setLayoutData(layoutData);
+		verticalSpacer.setText("");
+
+		Label macOSMessage = new Label(group, SWT.NONE);
+		layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
+		macOSMessage.setLayoutData(layoutData);
+		macOSMessage.setText(Messages.SetCrossCommandWizardPage_text);
+
+		// Layout need to be reset after fields are added
+		group.setLayout(groupLayout);
+
+		final Group group1 = new Group(parent, SWT.NONE);
+		group1.setText(Messages.GlobalToolchainsPathsPreferencesPage_ToolchainDefaultGroup_label);
+		GridLayout group1Layout = new GridLayout(2, false);
+		group1.setLayout(group1Layout);
+		group1.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+		FieldEditor toolchainNameField = new ToolchainsFieldEditor(PersistentPreferences.TOOLCHAIN_ID_KEY,
+				Messages.ToolchainName_label, group1);
+		toolchainNameField.fillIntoGrid(group1, 2);
+		// ComboFieldEditor does not grab excess space (like StringFieldEditor does) therefore
+		// we need to specify that here. ComboFieldEditor also doesn't provide an equivalent
+		// to StringFieldEditor.getTextControl, hence the need to get control's layout data
+		// like this
+		((GridData) group1.getChildren()[1].getLayoutData()).grabExcessHorizontalSpace = true;
+		addField(toolchainNameField);
+		// Layout need to be reset after fields are added
+		group1.setLayout(group1Layout);
 	}
 
+	@Override
+	protected void adjustGridLayout() {
+		// do nothing as we are manually handling the grid layout in createFieldEditors
+	}
 	// ------------------------------------------------------------------------
 }

--- a/plugins/org.eclipse.embedcdt.managedbuild.cross.riscv.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/riscv/ui/properties/ProjectToolchainsPathPropertiesPage.java
+++ b/plugins/org.eclipse.embedcdt.managedbuild.cross.riscv.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/riscv/ui/properties/ProjectToolchainsPathPropertiesPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Liviu Ionescu.
+ * Copyright (c) 2015, 2023 Liviu Ionescu and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,8 +15,11 @@
 
 package org.eclipse.embedcdt.internal.managedbuild.cross.riscv.ui.properties;
 
-import java.util.HashSet;
+import java.util.Comparator;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 import org.eclipse.cdt.managedbuilder.core.BuildException;
 import org.eclipse.cdt.managedbuilder.core.IConfiguration;
@@ -27,6 +30,8 @@ import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.embedcdt.core.EclipseUtils;
 import org.eclipse.embedcdt.internal.managedbuild.cross.riscv.ui.Activator;
 import org.eclipse.embedcdt.internal.managedbuild.cross.riscv.ui.Messages;
+import org.eclipse.embedcdt.internal.managedbuild.cross.riscv.ui.preferences.GlobalToolchainsPathsPreferencesPage;
+import org.eclipse.embedcdt.internal.managedbuild.cross.riscv.ui.preferences.WorkspaceToolchainsPathsPreferencesPage;
 import org.eclipse.embedcdt.managedbuild.cross.core.preferences.DefaultPreferences;
 import org.eclipse.embedcdt.managedbuild.cross.core.preferences.PersistentPreferences;
 import org.eclipse.embedcdt.managedbuild.cross.riscv.core.Option;
@@ -35,11 +40,19 @@ import org.eclipse.embedcdt.ui.FieldEditorPropertyPage;
 import org.eclipse.embedcdt.ui.LabelFakeFieldEditor;
 import org.eclipse.embedcdt.ui.XpackDirectoryNotStrictFieldEditor;
 import org.eclipse.embedcdt.ui.preferences.ScopedPreferenceStoreWithoutDefaults;
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.PixelConverter;
 import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
+import org.eclipse.ui.dialogs.PreferencesUtil;
 
 public class ProjectToolchainsPathPropertiesPage extends FieldEditorPropertyPage {
 
@@ -76,21 +89,49 @@ public class ProjectToolchainsPathPropertiesPage extends FieldEditorPropertyPage
 		return null;
 	}
 
+	/**
+	 * Creates the field editors. Field editors are abstractions of the common GUI
+	 * blocks needed to manipulate various types of preferences. Each field editor
+	 * knows how to save and restore itself.
+	 */
 	@Override
 	protected void createFieldEditors() {
+		final Composite parent = getFieldEditorParent();
+		final GridLayout layout = new GridLayout();
+		layout.marginWidth = 0;
+		parent.setLayout(layout);
 
-		boolean isStrict;
+		Link link = new Link(parent, SWT.NONE);
+		link.setText(Messages.ProjectToolchainsPathPropertiesPage_GlobalSettings_link);
+		link.setLayoutData(GridDataFactory.fillDefaults().create());
+		link.addListener(SWT.Selection, e -> {
+			PreferencesUtil
+					.createPreferenceDialogOn(parent.getShell(), GlobalToolchainsPathsPreferencesPage.ID, new String[] {
+							WorkspaceToolchainsPathsPreferencesPage.ID, GlobalToolchainsPathsPreferencesPage.ID }, null)
+					.open();
+		});
+		link = new Link(parent, SWT.NONE);
+		link.setText(Messages.ProjectToolchainsPathPropertiesPage_WorkspaceSettings_link);
+		link.setLayoutData(GridDataFactory.fillDefaults().create());
+		link.addListener(SWT.Selection, e -> {
+			PreferencesUtil.createPreferenceDialogOn(parent.getShell(), WorkspaceToolchainsPathsPreferencesPage.ID,
+					new String[] { WorkspaceToolchainsPathsPreferencesPage.ID,
+							GlobalToolchainsPathsPreferencesPage.ID },
+					null).open();
+		});
 
-		Set<ToolchainDefinition> toolchains = new HashSet<>();
+		Map<ToolchainDefinition, Set<String>> toolchains = new TreeMap<>(
+				Comparator.comparing(ToolchainDefinition::getName));
 
 		Object element = getElement();
 		if (element instanceof IProject) {
-			// TODO: get project toolchain name. How?
 			IProject project = (IProject) element;
 			IConfiguration[] configs = EclipseUtils.getConfigurationsForProject(project);
+			boolean allConfigsUseSameToolchain = true;
+			ToolchainDefinition toolchainInUse = null;
 			if (configs != null) {
-				for (int i = 0; i < configs.length; ++i) {
-					IToolChain toolchain = configs[i].getToolChain();
+				for (IConfiguration config : configs) {
+					IToolChain toolchain = config.getToolChain();
 					if (toolchain == null) {
 						continue;
 					}
@@ -99,7 +140,15 @@ public class ProjectToolchainsPathPropertiesPage extends FieldEditorPropertyPage
 						try {
 							String toolchainId = optionId.getStringValue();
 							int ix = ToolchainDefinition.findToolchainById(toolchainId);
-							toolchains.add(ToolchainDefinition.getToolchain(ix));
+
+							ToolchainDefinition toolchainDefinition = ToolchainDefinition.getToolchain(ix);
+							if (toolchainInUse == null) {
+								toolchainInUse = toolchainDefinition;
+							} else if (!toolchainInUse.equals(toolchainDefinition)) {
+								allConfigsUseSameToolchain = false;
+							}
+							var buildConfigsSet = toolchains.computeIfAbsent(toolchainDefinition, x -> new TreeSet<>());
+							buildConfigsSet.add(config.getName());
 							continue;
 						} catch (BuildException e) {
 						} catch (IndexOutOfBoundsException e) {
@@ -110,13 +159,27 @@ public class ProjectToolchainsPathPropertiesPage extends FieldEditorPropertyPage
 						try {
 							String toolchainName = optionName.getStringValue();
 							int ix = ToolchainDefinition.findToolchainByName(toolchainName);
-							toolchains.add(ToolchainDefinition.getToolchain(ix));
-							continue;
+
+							ToolchainDefinition toolchainDefinition = ToolchainDefinition.getToolchain(ix);
+							if (toolchainInUse == null) {
+								toolchainInUse = toolchainDefinition;
+							} else if (!toolchainInUse.equals(toolchainDefinition)) {
+								allConfigsUseSameToolchain = false;
+							}
+							var buildConfigsSet = toolchains.computeIfAbsent(toolchainDefinition, x -> new TreeSet<>());
+							buildConfigsSet.add(config.getName());
 						} catch (BuildException e) {
 						} catch (IndexOutOfBoundsException e) {
 						}
 					}
 				}
+			}
+
+			if (allConfigsUseSameToolchain && toolchainInUse != null) {
+				Set<String> set = toolchains.get(toolchainInUse);
+				// If all the configurations use the same toolchain, don't display
+				// any of the configurations in the UI
+				set.clear();
 			}
 		}
 
@@ -124,7 +187,7 @@ public class ProjectToolchainsPathPropertiesPage extends FieldEditorPropertyPage
 			try {
 				String toolchainId = fPersistentPreferences.getToolchainId();
 				int ix = ToolchainDefinition.findToolchainById(toolchainId);
-				toolchains.add(ToolchainDefinition.getToolchain(ix));
+				toolchains.computeIfAbsent(ToolchainDefinition.getToolchain(ix), x -> Set.of());
 			} catch (IndexOutOfBoundsException e) {
 			}
 		}
@@ -133,37 +196,84 @@ public class ProjectToolchainsPathPropertiesPage extends FieldEditorPropertyPage
 			try {
 				String toolchainName = fPersistentPreferences.getToolchainName();
 				int ix = ToolchainDefinition.findToolchainByName(toolchainName);
-				toolchains.add(ToolchainDefinition.getToolchain(ix));
+				toolchains.computeIfAbsent(ToolchainDefinition.getToolchain(ix), x -> Set.of());
 			} catch (IndexOutOfBoundsException e) {
 			}
 		}
 
 		if (toolchains.isEmpty()) {
 			int ix = ToolchainDefinition.getDefault();
-			toolchains.add(ToolchainDefinition.getToolchain(ix));
+			toolchains.computeIfAbsent(ToolchainDefinition.getToolchain(ix), x -> Set.of());
 		}
 
-		for (ToolchainDefinition toolchain : toolchains) {
+		final Group group = new Group(parent, SWT.NONE);
+		group.setText(Messages.GlobalToolchainsPathsPreferencesPage_ToolchainPathGroup_label);
+		GridLayout groupLayout = new GridLayout(4, false);
+		group.setLayout(groupLayout);
+		group.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+		boolean first = true;
+		for (var entry : toolchains.entrySet()) {
+			if (first) {
+				first = false;
+			} else {
+				Label verticalSpacer = new Label(group, SWT.NONE);
+				GridData layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
+				verticalSpacer.setLayoutData(layoutData);
+				verticalSpacer.setText("");
+			}
+
+			ToolchainDefinition toolchain = entry.getKey();
+			var configSet = entry.getValue();
+
+			Label message = new Label(group, SWT.WRAP);
+			GridData layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
+			message.setLayoutData(layoutData);
+			if (configSet.isEmpty()) {
+				message.setText(Messages.ProjectToolchainsPathPropertiesPage_ToolchainMessageAllConfigs_label);
+			} else {
+				String collected = String.join(", ", configSet);
+				message.setText(NLS.bind(Messages.ProjectToolchainsPathPropertiesPage_ToolchainMessageSomeConfigs_label,
+						collected));
+			}
+			PixelConverter pixelConverter = new PixelConverter(message);
+			layoutData.widthHint = pixelConverter
+					.convertWidthInCharsToPixels(Math.min(message.getText().length(), 100));
 
 			FieldEditor labelField = new LabelFakeFieldEditor(toolchain.getFullName(),
-					Messages.ToolsPaths_ToolchainName_label, getFieldEditorParent());
+					Messages.ToolsPaths_ToolchainName_label, group);
+			labelField.fillIntoGrid(group, 4);
 			addField(labelField);
 
-			isStrict = fDefaultPreferences.getBoolean(PersistentPreferences.PROJECT_TOOLCHAIN_PATH_STRICT, true);
+			boolean isStrict = fDefaultPreferences.getBoolean(PersistentPreferences.PROJECT_TOOLCHAIN_PATH_STRICT,
+					true);
 
 			String[] xpackNames = fDefaultPreferences.getToolchainXpackNames(toolchain.getId(), toolchain.getName());
 
 			String key = PersistentPreferences.getToolchainKey(toolchain.getId(), toolchain.getName());
 			FieldEditor toolchainPathField = new XpackDirectoryNotStrictFieldEditor(xpackNames, key,
-					Messages.ToolchainPaths_label, getFieldEditorParent(), isStrict);
-
+					Messages.ToolchainPaths_label, group, isStrict);
+			toolchainPathField.fillIntoGrid(group, 4);
 			addField(toolchainPathField);
 		}
 
-		Label message = new Label(getFieldEditorParent(), SWT.NONE);
+		Label verticalSpacer = new Label(group, SWT.NONE);
 		GridData layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
-		message.setLayoutData(layoutData);
-		message.setText(Messages.SetCrossCommandWizardPage_text);
+		verticalSpacer.setLayoutData(layoutData);
+		verticalSpacer.setText("");
+
+		Label macOSMessage = new Label(group, SWT.NONE);
+		layoutData = new GridData(SWT.FILL, SWT.CENTER, true, false, 4, 1);
+		macOSMessage.setLayoutData(layoutData);
+		macOSMessage.setText(Messages.SetCrossCommandWizardPage_text);
+
+		// Layout need to be reset after fields are added
+		group.setLayout(groupLayout);
+	}
+
+	@Override
+	protected void adjustGridLayout() {
+		// do nothing as we are manually handling the grid layout in createFieldEditors
 	}
 
 	// ------------------------------------------------------------------------

--- a/plugins/org.eclipse.embedcdt.ui/src/org/eclipse/embedcdt/ui/XpackDirectoryNotStrictFieldEditor.java
+++ b/plugins/org.eclipse.embedcdt.ui/src/org/eclipse/embedcdt/ui/XpackDirectoryNotStrictFieldEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Liviu Ionescu.
+ * Copyright (c) 2018, 2023 Liviu Ionescu and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -69,24 +69,33 @@ public class XpackDirectoryNotStrictFieldEditor extends DirectoryNotStrictFieldE
 	@Override
 	protected void doFillIntoGrid(Composite parent, int numColumns) {
 		super.doFillIntoGrid(parent, numColumns - 1);
-
-		fXpackButton = new Button(parent, SWT.PUSH);
-		fXpackButton.setText("xPack...");
-		fXpackButton.setFont(parent.getFont());
-		fXpackButton.addSelectionListener(new SelectionAdapter() {
-			@Override
-			public void widgetSelected(SelectionEvent event) {
-				buttonPressed(event);
-			}
-		});
+		fXpackButton = getXPackButton(parent);
 
 		GridData gd = new GridData();
 		gd.horizontalAlignment = GridData.FILL;
 		int widthHint = convertHorizontalDLUsToPixels(fXpackButton, IDialogConstants.BUTTON_WIDTH);
 		gd.widthHint = Math.max(widthHint, fXpackButton.computeSize(SWT.DEFAULT, SWT.DEFAULT, true).x);
 		fXpackButton.setLayoutData(gd);
+	}
 
-		fXpackButton.setEnabled(false);
+	private Button getXPackButton(Composite parent) {
+		if (fXpackButton == null) {
+			fXpackButton = new Button(parent, SWT.PUSH);
+			fXpackButton.setText("xPack...");
+			fXpackButton.setFont(parent.getFont());
+			fXpackButton.addSelectionListener(new SelectionAdapter() {
+				@Override
+				public void widgetSelected(SelectionEvent event) {
+					buttonPressed(event);
+				}
+			});
+
+			fXpackButton.setEnabled(false);
+		} else {
+			checkParent(fXpackButton, parent);
+		}
+
+		return fXpackButton;
 	}
 
 	private void buttonPressed(SelectionEvent e) {


### PR DESCRIPTION
- groups around the global and per-toolchain settings with labels
- whitespace between different toolchain settings
- new logic that shows which projects + build configs are using each displayed toolchain
- added links on the project properties pages back to the global and workspace preferences
- updated the descriptions in the pages

The change in XpackDirectoryNotStrictFieldEditor fixes the implementation to allow doFillIntoGrid to be called multiple times. This is how the other field editors handle it. This is needed now because of how the layout is now being handled with the extra layer of UI hierarchy.

TODO:

- [x] Have this design reviewed - see #574
- [x] Apply the same changes to the other property and preference pages (RISC-V/ARM and Global/Workspace/Project) - 6 classes in total.

Fixes #574