### PR TITLE
Enable Externalize Strings tooling

### DIFF
--- a/plugins/org.eclipse.embedcdt.codered.ui/src/org/eclipse/embedcdt/internal/codered/ui/Messages.java
+++ b/plugins/org.eclipse.embedcdt.codered.ui/src/org/eclipse/embedcdt/internal/codered/ui/Messages.java
@@ -18,7 +18,7 @@ import org.eclipse.osgi.util.NLS;
 
 public class Messages extends NLS {
 
-	private static final String MESSAGES = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
+	private static final String MESSAGES = "org.eclipse.embedcdt.internal.codered.ui.messages"; //$NON-NLS-1$
 
 	// public static String MyMessage_text;
 

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.jlink.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/jlink/ui/Messages.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.jlink.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/jlink/ui/Messages.java
@@ -25,7 +25,7 @@ public class Messages {
 
 	// ------------------------------------------------------------------------
 
-	private static final String MESSAGES = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
+	private static final String MESSAGES = "org.eclipse.embedcdt.internal.debug.gdbjtag.jlink.ui.messages"; //$NON-NLS-1$
 
 	public static String ProjectMcuPagePropertyPage_description;
 	public static String WorkspaceMcuPagePropertyPage_description;

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.openocd.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/openocd/ui/Messages.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.openocd.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/openocd/ui/Messages.java
@@ -25,7 +25,7 @@ public class Messages {
 
 	// ------------------------------------------------------------------------
 
-	private static final String MESSAGES = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
+	private static final String MESSAGES = "org.eclipse.embedcdt.internal.debug.gdbjtag.openocd.ui.messages"; //$NON-NLS-1$
 
 	public static String ProjectMcuPagePropertyPage_description;
 	public static String WorkspaceMcuPagePropertyPage_description;

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/pyocd/ui/Messages.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.pyocd.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/pyocd/ui/Messages.java
@@ -26,7 +26,7 @@ public class Messages {
 
 	// ------------------------------------------------------------------------
 
-	private static final String MESSAGES = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
+	private static final String MESSAGES = "org.eclipse.embedcdt.internal.debug.gdbjtag.pyocd.ui.messages"; //$NON-NLS-1$
 
 	public static String ProjectMcuPagePropertyPage_description;
 	public static String WorkspaceMcuPagePropertyPage_description;

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.qemu.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/qemu/ui/Messages.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.qemu.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/qemu/ui/Messages.java
@@ -25,7 +25,7 @@ public class Messages {
 
 	// ------------------------------------------------------------------------
 
-	private static final String MESSAGES = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
+	private static final String MESSAGES = "org.eclipse.embedcdt.internal.debug.gdbjtag.qemu.ui.messages"; //$NON-NLS-1$
 
 	public static String ProjectMcuPagePropertyPage_description;
 	public static String WorkspaceMcuPagePropertyPage_description;

--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/ui/Messages.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.ui/src/org/eclipse/embedcdt/internal/debug/gdbjtag/ui/Messages.java
@@ -22,7 +22,7 @@ import org.eclipse.osgi.util.NLS;
 
 public class Messages extends NLS {
 
-	private static final String MESSAGES = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
+	private static final String MESSAGES = "org.eclipse.embedcdt.internal.debug.gdbjtag.ui.messages"; //$NON-NLS-1$
 
 	public static String PeripheralsView_NameColumn_text;
 	public static String PeripheralsView_AddressColumn_text;

--- a/plugins/org.eclipse.embedcdt.managedbuild.cross.arm.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/arm/ui/Messages.java
+++ b/plugins/org.eclipse.embedcdt.managedbuild.cross.arm.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/arm/ui/Messages.java
@@ -25,7 +25,7 @@ public class Messages extends NLS {
 
 	// ------------------------------------------------------------------------
 
-	private static final String MESSAGES = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
+	private static final String MESSAGES = "org.eclipse.embedcdt.internal.managedbuild.cross.arm.ui.messages"; //$NON-NLS-1$
 
 	public static String SetCrossCommandWizardPage_browse;
 	public static String SetCrossCommandWizardPage_description;

--- a/plugins/org.eclipse.embedcdt.managedbuild.cross.riscv.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/riscv/ui/Messages.java
+++ b/plugins/org.eclipse.embedcdt.managedbuild.cross.riscv.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/riscv/ui/Messages.java
@@ -26,7 +26,7 @@ public class Messages extends NLS {
 
 	// ------------------------------------------------------------------------
 
-	private static final String MESSAGES = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
+	private static final String MESSAGES = "org.eclipse.embedcdt.internal.managedbuild.cross.riscv.ui.messages"; //$NON-NLS-1$
 
 	public static String SetCrossCommandWizardPage_browse;
 	public static String SetCrossCommandWizardPage_description;

--- a/plugins/org.eclipse.embedcdt.managedbuild.cross.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/ui/Messages.java
+++ b/plugins/org.eclipse.embedcdt.managedbuild.cross.ui/src/org/eclipse/embedcdt/internal/managedbuild/cross/ui/Messages.java
@@ -25,7 +25,7 @@ public class Messages extends NLS {
 
 	// ------------------------------------------------------------------------
 
-	private static final String MESSAGES = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
+	private static final String MESSAGES = "org.eclipse.embedcdt.internal.managedbuild.cross.ui.messages"; //$NON-NLS-1$
 
 	public static String McuPropertiesPage_description;
 	public static String BuildToolsPaths_label;

--- a/plugins/org.eclipse.embedcdt.managedbuild.packs.ui/src/org/eclipse/embedcdt/internal/managedbuild/packs/ui/Messages.java
+++ b/plugins/org.eclipse.embedcdt.managedbuild.packs.ui/src/org/eclipse/embedcdt/internal/managedbuild/packs/ui/Messages.java
@@ -22,7 +22,7 @@ import org.eclipse.osgi.util.NLS;
 
 public class Messages extends NLS {
 
-	private static final String MESSAGES = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
+	private static final String MESSAGES = "org.eclipse.embedcdt.internal.managedbuild.packs.ui.messages"; //$NON-NLS-1$
 
 	public static String DevicesTab_DeviceGroup_name;
 	public static String DevicesTab_DeviceGroup_architecture_label;

--- a/plugins/org.eclipse.embedcdt.packs.ui/src/org/eclipse/embedcdt/internal/packs/ui/Messages.java
+++ b/plugins/org.eclipse.embedcdt.packs.ui/src/org/eclipse/embedcdt/internal/packs/ui/Messages.java
@@ -19,7 +19,7 @@ import org.eclipse.osgi.util.NLS;
 
 public class Messages extends NLS {
 
-	private static final String MESSAGES = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
+	private static final String MESSAGES = "org.eclipse.embedcdt.internal.packs.ui.messages"; //$NON-NLS-1$
 
 	public static String NewSiteDialog_label_title_edit;
 	public static String NewSiteDialog_label_title_new;

--- a/plugins/org.eclipse.embedcdt.ui/src/org/eclipse/embedcdt/internal/ui/Messages.java
+++ b/plugins/org.eclipse.embedcdt.ui/src/org/eclipse/embedcdt/internal/ui/Messages.java
@@ -24,7 +24,7 @@ public class Messages extends NLS {
 
 	// ------------------------------------------------------------------------
 
-	private static final String MESSAGES = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
+	private static final String MESSAGES = "org.eclipse.embedcdt.internal.ui.messages"; //$NON-NLS-1$
 
 	public static String McuPropertiesPage_description;
 	public static String McuPreferencesPage_description;


### PR DESCRIPTION
In commit 485c41b6f59a327d2aae3a890e7f2b90f56ef037 the code was refactored in a such a way that prevented the externalize string tooling in Eclipse from working properly.

This change provides the messages classes with a way that the tooling in Eclipse works, enabling Ctrl-Click and hovering on the externalized strings to work as expected and allows the externalize strings wizard to find the correct Messages class to add new strings to.