### PR TITLE
update gdb, telnet, and tcl to use non-deprecated calling format

### DIFF
--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.openocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/openocd/core/Configuration.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.openocd.core/src/org/eclipse/embedcdt/debug/gdbjtag/openocd/core/Configuration.java
@@ -82,17 +82,17 @@ public class Configuration {
 			lst.add(executable);
 
 			lst.add("-c");
-			lst.add("gdb_port "
+			lst.add("gdb port "
 					+ Integer.toString(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_GDB_PORT_NUMBER,
 							DefaultPreferences.GDB_SERVER_GDB_PORT_NUMBER_DEFAULT)));
 
 			lst.add("-c");
-			lst.add("telnet_port "
+			lst.add("telnet port "
 					+ Integer.toString(configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_TELNET_PORT_NUMBER,
 							DefaultPreferences.GDB_SERVER_TELNET_PORT_NUMBER_DEFAULT)));
 
 			lst.add("-c");
-			lst.add("tcl_port " + configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_TCL_PORT_NUMBER,
+			lst.add("tcl port " + configuration.getAttribute(ConfigurationAttributes.GDB_SERVER_TCL_PORT_NUMBER,
 					DefaultPreferences.GDB_SERVER_TCL_PORT_NUMBER_DEFAULT));
 
 			String other = configuration


### PR DESCRIPTION
When starting an openOCD debug session, warnings are generated that state the gdb_port, telnet_port, and tcl_port command formats are deprecated.  This pull request updates the code by removing the underscore.  Implementing these changes will remove the warning.

There would probably be an issue with backward compatibility if people are using older versions of openOCD.  I don't know how long the commands have been marked as deprecated.

Update tested with: Eclipse Embedded CDT (2024-12), OpenOCD Debugging (6.6.1.202408270735), XPack openocd (0.12.0-6-1)