### PR TITLE
Fixed: Memory view not supporting 64-bit address while using GnuMcuLaunch

### DIFF
--- a/plugins/org.eclipse.embedcdt.debug.gdbjtag.core/src/org/eclipse/embedcdt/debug/gdbjtag/core/memory/PeripheralMemoryBlockRetrieval.java
+++ b/plugins/org.eclipse.embedcdt.debug.gdbjtag.core/src/org/eclipse/embedcdt/debug/gdbjtag/core/memory/PeripheralMemoryBlockRetrieval.java
@@ -20,11 +20,11 @@ import java.util.List;
 
 import org.eclipse.cdt.dsf.datamodel.DMContexts;
 import org.eclipse.cdt.dsf.datamodel.IDMContext;
-import org.eclipse.cdt.dsf.debug.model.DsfMemoryBlockRetrieval;
 import org.eclipse.cdt.dsf.debug.service.IMemory;
 import org.eclipse.cdt.dsf.debug.service.IMemory.IMemoryDMContext;
 import org.eclipse.cdt.dsf.debug.service.IRunControl.IExitedDMEvent;
 import org.eclipse.cdt.dsf.gdb.internal.GdbPlugin;
+import org.eclipse.cdt.dsf.gdb.internal.memory.GdbMemoryBlockRetrieval;
 import org.eclipse.cdt.dsf.internal.DsfPlugin;
 import org.eclipse.cdt.dsf.service.DsfServiceEventHandler;
 import org.eclipse.cdt.dsf.service.DsfSession;
@@ -46,7 +46,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 @SuppressWarnings("restriction")
-public class PeripheralMemoryBlockRetrieval extends DsfMemoryBlockRetrieval {
+public class PeripheralMemoryBlockRetrieval extends GdbMemoryBlockRetrieval {
 
 	// ------------------------------------------------------------------------
 


### PR DESCRIPTION
Fix for: https://github.com/eclipse-embed-cdt/eclipse-plugins/discussions/645

CDT have added support for 64-bit memory addresses long before. Code changes for the support are in the class GdbMemoryBlockRetrieval which inherits from DsfMemoryBlockRetrieval. Embedded CDT launches are using GnuMcuLaunch class (Embedded CDT launcher, used to initialize the memory block retrieval used by the Peripherals view). This launcher uses PeripheralMemoryBlockRetrieval which directly inherits from DsfMemoryBlockRetrieval and misses the 64-bit support in GdbMemoryBlockRetrieval class. If parent class of PeripheralMemoryBlockRetrieval is changed to GdbMemoryBlockRetrieval memory view correctly displays the address contents.