### PR TITLE
Launch xpm in a PTY

### DIFF
--- a/plugins/org.eclipse.embedcdt.core/src/org/eclipse/embedcdt/core/EclipseUtils.java
+++ b/plugins/org.eclipse.embedcdt.core/src/org/eclipse/embedcdt/core/EclipseUtils.java
@@ -30,6 +30,8 @@ import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
 import org.eclipse.cdt.managedbuilder.core.IConfiguration;
 import org.eclipse.cdt.managedbuilder.core.IManagedBuildInfo;
 import org.eclipse.cdt.managedbuilder.core.ManagedBuildManager;
+import org.eclipse.cdt.utils.pty.PTY;
+import org.eclipse.cdt.utils.pty.PTY.Mode;
 import org.eclipse.cdt.utils.spawner.ProcessFactory;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ProjectScope;
@@ -522,7 +524,12 @@ public class EclipseUtils {
 		List<String> outputLines = new ArrayList<>();
 		try {
 			BufferedReader reader = null;
-			Process process = ProcessFactory.getFactory().exec(cmdArray, envp);
+			Process process;
+			if (!PTY.isSupported(Mode.TERMINAL) || Platform.OS_WIN32.equals(Platform.getOS())) {
+				process = ProcessFactory.getFactory().exec(cmdArray, envp);
+			} else {
+				process = ProcessFactory.getFactory().exec(cmdArray, envp, null, new PTY(Mode.TERMINAL));
+			}
 			reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
 
 			String line;

--- a/plugins/org.eclipse.embedcdt.templates.core/src/org/eclipse/embedcdt/templates/core/processes/ConditionalRunCommand.java
+++ b/plugins/org.eclipse.embedcdt.templates.core/src/org/eclipse/embedcdt/templates/core/processes/ConditionalRunCommand.java
@@ -26,6 +26,8 @@ import org.eclipse.cdt.core.templateengine.TemplateCore;
 import org.eclipse.cdt.core.templateengine.process.ProcessArgument;
 import org.eclipse.cdt.core.templateengine.process.ProcessFailureException;
 import org.eclipse.cdt.core.templateengine.process.ProcessRunner;
+import org.eclipse.cdt.utils.pty.PTY;
+import org.eclipse.cdt.utils.pty.PTY.Mode;
 import org.eclipse.cdt.utils.spawner.ProcessFactory;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -33,6 +35,7 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.embedcdt.core.EclipseUtils;
 import org.eclipse.embedcdt.core.StringUtils;
 import org.eclipse.embedcdt.internal.core.Activator;
@@ -150,7 +153,12 @@ public class ConditionalRunCommand extends ProcessRunner {
 
 		try {
 			BufferedReader reader = null;
-			Process process = ProcessFactory.getFactory().exec(cmdArray, envp, dir);
+			Process process;
+			if (!PTY.isSupported(Mode.TERMINAL) || Platform.OS_WIN32.equals(Platform.getOS())) {
+				process = ProcessFactory.getFactory().exec(cmdArray, envp, dir);
+			} else {
+				process = ProcessFactory.getFactory().exec(cmdArray, envp, dir, new PTY(Mode.TERMINAL));
+			}
 			reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
 
 			String line;

--- a/plugins/org.eclipse.embedcdt.ui/src/org/eclipse/embedcdt/ui/templates/core/processes/ConditionalRunCommandUi.java
+++ b/plugins/org.eclipse.embedcdt.ui/src/org/eclipse/embedcdt/ui/templates/core/processes/ConditionalRunCommandUi.java
@@ -13,6 +13,8 @@ import org.eclipse.cdt.core.templateengine.TemplateCore;
 import org.eclipse.cdt.core.templateengine.process.ProcessArgument;
 import org.eclipse.cdt.core.templateengine.process.ProcessFailureException;
 import org.eclipse.cdt.core.templateengine.process.ProcessRunner;
+import org.eclipse.cdt.utils.pty.PTY;
+import org.eclipse.cdt.utils.pty.PTY.Mode;
 import org.eclipse.cdt.utils.spawner.ProcessFactory;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -20,6 +22,7 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.embedcdt.core.EclipseUtils;
 import org.eclipse.embedcdt.core.StringUtils;
 import org.eclipse.embedcdt.internal.ui.Activator;
@@ -150,7 +153,12 @@ public class ConditionalRunCommandUi extends ProcessRunner {
 				try {
 					BufferedReader reader = null;
 					pm.worked(1);
-					Process process = ProcessFactory.getFactory().exec(cmdArray, envp, dir);
+					Process process;
+					if (!PTY.isSupported(Mode.TERMINAL) || Platform.OS_WIN32.equals(Platform.getOS())) {
+						process = ProcessFactory.getFactory().exec(cmdArray, envp, dir);
+					} else {
+						process = ProcessFactory.getFactory().exec(cmdArray, envp, dir, new PTY(Mode.TERMINAL));
+					}
 					pm.worked(1);
 					reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
 


### PR DESCRIPTION
By launching in a PTY the `bash -i` won't have its stdin connected to the stdin of Eclipse, meaning it will properly behave and not stop with a SIGTTIN when bash tries to read.

Fixes https://github.com/eclipse-embed-cdt/eclipse-plugins/issues/626